### PR TITLE
[nrf5-examples] Add information about platform being deprecated

### DIFF
--- a/examples/lighting-app/nrf5/README.md
+++ b/examples/lighting-app/nrf5/README.md
@@ -1,5 +1,14 @@
 # CHIP nRF52840 Lighting Example Application
 
+### :warning: nRF5 platform deprecated
+
+> This platform based on the nRF5 SDK for Thread and Zigbee is in maintenance
+> mode and support for it will be removed from the CHIP project
+> repository.<br /><br /> To develop CHIP applications on Nordic Semiconductor
+> devices such as nRF52840, use the platform based on the
+> [nRF Connect SDK](https://www.nordicsemi.com/Software-and-tools/Software/nRF-Connect-SDK),
+> located in the **[lighting-app/nrfconnect](../nrfconnect)** directory.
+
 An example application showing the use
 [CHIP](https://github.com/project-chip/connectedhomeip) on the Nordic nRF52840.
 

--- a/examples/lock-app/nrf5/README.md
+++ b/examples/lock-app/nrf5/README.md
@@ -1,5 +1,14 @@
 # CHIP nRF52840 Lock Example Application
 
+### :warning: nRF5 platform deprecated
+
+> This platform based on the nRF5 SDK for Thread and Zigbee is in maintenance
+> mode and support for it will be removed from the CHIP project
+> repository.<br /><br /> To develop CHIP applications on Nordic Semiconductor
+> devices such as nRF52840, use the platform based on the
+> [nRF Connect SDK](https://www.nordicsemi.com/Software-and-tools/Software/nRF-Connect-SDK),
+> located in the **[lock-app/nrfconnect](../nrfconnect)** directory.
+
 An example application showing the use
 [CHIP](https://github.com/project-chip/connectedhomeip) on the Nordic nRF52840.
 


### PR DESCRIPTION
 #### Problem
This platform based on the nRF5 SDK for Thread and Zigbee is in the maintainance mode and support for it will be removed from the CHIP project repository.

To develop CHIP applications on Nordic Semiconductor devices such as nRF52840, developers can use the platform based on the nRF Connect SDK.

#### Summary of Changes
Add information about deprecation of nRF5 SDK platform to the example's README and building process.


fixes: 3075 (will link to it on official PR)
