### PR TITLE
[doc] enhance documentation of Python CHIP controller

### DIFF
--- a/scripts/build_python.sh
+++ b/scripts/build_python.sh
@@ -105,7 +105,7 @@ virtualenv --clear "$ENVIRONMENT_ROOT"
 # Activate the new enviroment to register the python WHL
 source "$ENVIRONMENT_ROOT"/bin/activate
 "$ENVIRONMENT_ROOT"/bin/python -m pip install --upgrade pip
-"$ENVIRONMENT_ROOT"/bin/pip install "$OUTPUT_ROOT"/controller/python/chip-*.whl
+"$ENVIRONMENT_ROOT"/bin/pip install --upgrade --force-reinstall --no-cache-dir "$OUTPUT_ROOT"/controller/python/chip-*.whl
 
 echo ""
 echo_green "Compilation completed and WHL package installed in: "

--- a/src/controller/python/ADVANCED_USAGE.md
+++ b/src/controller/python/ADVANCED_USAGE.md
@@ -1,61 +1,66 @@
 # Python CHIP Device Controller - Advanced usage
 
-This document extends the [basic documentation](README.md) with the useful information when developing Python CHIP controller tool or Matter accessories on Linux.
+This document extends the [basic documentation](README.md) with the useful
+information when developing Python CHIP controller tool or Matter accessories on
+Linux.
 
 ## Bluetooth LE virtualization on Linux
 
-Commissioning over Bluetooth LE can be tested even if the controller and the device run on the same machine. To that end, you will need to set up two virtual interfaces working as Bluetooth LE central and peripheral, respectively.
+Commissioning over Bluetooth LE can be tested even if the controller and the
+device run on the same machine. To that end, you will need to set up two virtual
+interfaces working as Bluetooth LE central and peripheral, respectively.
 
 1. Build `bluez` project from sources by completing the following steps:
 
-   ```
-   sudo apt-get update
-   sudo apt-get install libtool m4 automake autotools-dev libudev-dev libical-dev libreadline-dev
+    ```
+    sudo apt-get update
+    sudo apt-get install libtool m4 automake autotools-dev libudev-dev libical-dev libreadline-dev
 
-   cd third_party/bluez/repo
-   ./bootstrap
-   third_party/bluez/repo/configure --prefix=/usr --mandir=/usr/share/man --sysconfdir=/etc --localstatedir=/var --enable-experimental --with-systemdsystemunitdir=/lib/systemd/system --with-systemduserunitdir=/usr/lib/systemd --enable-deprecated --enable-testing --enable-tools
-   make
-   ```
+    cd third_party/bluez/repo
+    ./bootstrap
+    third_party/bluez/repo/configure --prefix=/usr --mandir=/usr/share/man --sysconfdir=/etc --localstatedir=/var --enable-experimental --with-systemdsystemunitdir=/lib/systemd/system --with-systemduserunitdir=/usr/lib/systemd --enable-deprecated --enable-testing --enable-tools
+    make
+    ```
 
 2. Run bluetoothd:
 
-   ```
-   sudo third_party/bluez/repo/src/bluetoothd --experimental --debug &
-   ```
+    ```
+    sudo third_party/bluez/repo/src/bluetoothd --experimental --debug &
+    ```
 
 3. Bring up two virtual Bluetooth LE interfaces:
 
-   ```
-   sudo third_party/bluez/repo/emulator/btvirt -L -l2
-   ```
+    ```
+    sudo third_party/bluez/repo/emulator/btvirt -L -l2
+    ```
 
-   You can find the virtual interface by running `hciconfig` command:
+    You can find the virtual interface by running `hciconfig` command:
 
-   ```
-   $ hciconfig
+    ```
+    $ hciconfig
 
-   hci2:	Type: Primary  Bus: Virtual
-      BD Address: 00:AA:01:01:00:24  ACL MTU: 192:1  SCO MTU: 0:0
-      UP RUNNING
-      RX bytes:0 acl:95 sco:0 events:205 errors:0
-      TX bytes:2691 acl:95 sco:0 commands:98 errors:0
+    hci2:	Type: Primary  Bus: Virtual
+       BD Address: 00:AA:01:01:00:24  ACL MTU: 192:1  SCO MTU: 0:0
+       UP RUNNING
+       RX bytes:0 acl:95 sco:0 events:205 errors:0
+       TX bytes:2691 acl:95 sco:0 commands:98 errors:0
 
-   hci1:	Type: Primary  Bus: Virtual
-      BD Address: 00:AA:01:00:00:23  ACL MTU: 192:1  SCO MTU: 0:0
-      UP RUNNING
-      RX bytes:0 acl:95 sco:0 events:208 errors:0
-      TX bytes:3488 acl:95 sco:0 commands:110 errors:0
-   ```
+    hci1:	Type: Primary  Bus: Virtual
+       BD Address: 00:AA:01:00:00:23  ACL MTU: 192:1  SCO MTU: 0:0
+       UP RUNNING
+       RX bytes:0 acl:95 sco:0 events:208 errors:0
+       TX bytes:3488 acl:95 sco:0 commands:110 errors:0
+    ```
 
-4. Run the Python CHIP Controller with Bluetooth LE adapter defined from a command line:
+4. Run the Python CHIP Controller with Bluetooth LE adapter defined from a
+   command line:
 
-   For example, add `--bluetooth-adapter=hci2` to use the virtual interface `hci2`
-   listed above.
+    For example, add `--bluetooth-adapter=hci2` to use the virtual interface
+    `hci2` listed above.
 
-   ```
-   chip-device-ctrl --bluetooth-adapter=hci2
-   ```
+    ```
+    chip-device-ctrl --bluetooth-adapter=hci2
+    ```
 
 ## Debugging with gdb
 

--- a/src/controller/python/ADVANCED_USAGE.md
+++ b/src/controller/python/ADVANCED_USAGE.md
@@ -1,0 +1,234 @@
+# Python CHIP Device Controller - Advanced usage
+
+## BLE Virtualization on Linux (Optional)
+
+If you would like to setup virtual BLE central and peripheral in the same
+machine, then follow below steps:
+
+```
+cd third_party/bluez/repo
+./bootstrap
+third_party/bluez/repo/configure --prefix=/usr --mandir=/usr/share/man --sysconfdir=/etc --localstatedir=/var --enable-experimental --with-systemdsystemunitdir=/lib/systemd/system --with-systemduserunitdir=/usr/lib/systemd --enable-deprecated --enable-testing --enable-tools
+make
+```
+
+Note: You also need to install several packages on RPi if you want to build
+bluez
+
+```
+sudo apt-get install libtool m4 automake autotools-dev libudev-dev libical-dev libreadline-dev
+```
+
+Run bluetoothd:
+
+```
+sudo third_party/bluez/repo/src/bluetoothd --experimental --debug &
+```
+
+Bring up two virtual ble interface:
+
+```
+sudo third_party/bluez/repo/emulator/btvirt -L -l2
+```
+
+You can find the virtual interface by `hciconfig` command:
+
+```
+$ hciconfig
+
+hci2:	Type: Primary  Bus: Virtual
+	BD Address: 00:AA:01:01:00:24  ACL MTU: 192:1  SCO MTU: 0:0
+	UP RUNNING
+	RX bytes:0 acl:95 sco:0 events:205 errors:0
+	TX bytes:2691 acl:95 sco:0 commands:98 errors:0
+
+hci1:	Type: Primary  Bus: Virtual
+	BD Address: 00:AA:01:00:00:23  ACL MTU: 192:1  SCO MTU: 0:0
+	UP RUNNING
+	RX bytes:0 acl:95 sco:0 events:208 errors:0
+	TX bytes:3488 acl:95 sco:0 commands:110 errors:0
+```
+
+Then you can choose the adapter to use in command line arguments of the device
+controller:
+
+For example, add `--bluetooth-adapter=hci2` to use the virtual interface `hci2`
+listed above.
+
+```
+chip-device-ctrl --bluetooth-adapter=hci2
+```
+
+## Debugging with gdb
+
+You can run the chip-device-ctrl under GDB for debugging, however, since the
+CHIP core support library is a dynamic library, you cannot read the symbols
+unless it is fully loaded.
+
+The following block is a example debug session using GDB
+
+```
+# GDB cannot run scripts directly
+# so you need to run Python3 with the path of device controller
+# Here, we use the feature from bash to get the path of chip-device-ctrl without typing it.
+$ gdb --args python3 `which chip-device-ctrl`
+GNU gdb (Ubuntu 10.1-2ubuntu2) 10.1.90.20210411-git
+Copyright (C) 2021 Free Software Foundation, Inc.
+License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
+This is free software: you are free to change and redistribute it.
+There is NO WARRANTY, to the extent permitted by law.
+Type "show copying" and "show warranty" for details.
+This GDB was configured as "aarch64-linux-gnu".
+Type "show configuration" for configuration details.
+For bug reporting instructions, please see:
+<https://www.gnu.org/software/gdb/bugs/>.
+Find the GDB manual and other documentation resources online at:
+    <http://www.gnu.org/software/gdb/documentation/>.
+
+For help, type "help".
+Type "apropos word" to search for commands related to "word"...
+Reading symbols from python3...
+(No debugging symbols found in python3)
+(gdb)
+```
+
+The Python will create lots of threads due to main loop, so you may want to
+supress thread related outputs first by `set print thread-events off`
+
+```
+(gdb) set print thread-events off
+(gdb)
+```
+
+We cannot set breakpoints here, since the GDB knows nothing about the CHIP
+library, let run the CHIP device controller first.
+
+```
+(gdb) run
+Starting program: /usr/bin/python3 /home/ubuntu/.local/bin/chip-device-ctrl
+[Thread debugging using libthread_db enabled]
+Using host libthread_db library "/lib/aarch64-linux-gnu/libthread_db.so.1".
+CHIP:DIS: Init admin pairing table with server storage.
+CHIP:IN: local node id is 0x000000000001b669
+CHIP:DL: MDNS failed to join multicast group on wpan0 for address type IPv4: Inet Error 1016 (0x000003F8): Address not found
+CHIP:ZCL: Using ZAP configuration...
+CHIP:ZCL: deactivate report event
+CHIP:CTL: Getting operational keys
+CHIP:CTL: Generating operational certificate for the controller
+CHIP:CTL: Getting root certificate for the controller from the issuer
+CHIP:CTL: Generating credentials
+CHIP:CTL: Loaded credentials successfully
+CHIP:DL: Platform main loop started.
+Chip Device Controller Shell
+
+chip-device-ctrl >
+```
+
+The prompt `chip-device-ctrl >` indicates that the CHIP core library is loaded
+by Python, you can browse the symbols in the CHIP core library, setting
+breakpoints on functions and many other functions provided by GDB.
+
+You can use `Ctrl-C` to send SIGINT to the controller anytime you want so you
+can set breakpoints.
+
+> (`Ctrl-C` pressed here.)
+
+```
+Thread 1 "python3" received signal SIGINT, Interrupt.
+0x0000fffff7db79ec in __GI___select (nfds=<optimized out>, readfds=0xffffffffe760, writefds=0x0, exceptfds=0x0, timeout=<optimized out>) at ../sysdeps/unix/sysv/linux/select.c:49
+49	../sysdeps/unix/sysv/linux/select.c: No such file or directory.
+(gdb)
+```
+
+For example, you can break on `DeviceCommissioner::PairDevice` by using `break`
+command in GDB (`b` for short)
+
+```
+(gdb) b DeviceCommissioner::PairDevice
+Breakpoint 1 at 0xfffff5b0f6b4 (2 locations)
+(gdb)
+```
+
+Type `continue` (`c` for short) to continue the device controller, you may need
+another hit of `Enter` to see the prompt.
+
+```
+(gdb) c
+Continuing.
+
+chip-device-ctrl >
+```
+
+Let do pairing over IP to see the effect of the breakpoint we just set.
+
+```
+chip-device-ctrl > connect -ip 192.168.50.5 20202021 1
+Device is assigned with nodeid = 1
+
+Thread 1 "python3" hit Breakpoint 1, 0x0000fffff5b0f6b4 in chip::Controller::DeviceCommissioner::PairDevice(unsigned long, chip::RendezvousParameters&)@plt ()
+   from /home/ubuntu/.local/lib/python3.9/site-packages/chip/_ChipDeviceCtrl.so
+(gdb)
+```
+
+The `@plt` symbol means it is a symbol used by dynamic library loader, type `c`
+(for `continue`) and it will break on the real function.
+
+```
+(gdb) c
+Continuing.
+
+Thread 1 "python3" hit Breakpoint 1, chip::Controller::DeviceCommissioner::PairDevice (this=0xd28540, remoteDeviceId=1, params=...) at ../../src/controller/CHIPDeviceController.cpp:827
+827	{
+(gdb)
+```
+
+You can find the `this` pointer, and value of arguments passed to this function,
+then you can use `bt` (for `backtrace`) to see the backtrace of the call stack.
+
+```
+(gdb) bt
+#0  chip::Controller::DeviceCommissioner::PairDevice(unsigned long, chip::RendezvousParameters&) (this=0xd28540, remoteDeviceId=1, params=...)
+    at ../../src/controller/CHIPDeviceController.cpp:827
+#1  0x0000fffff5b3095c in pychip_DeviceController_ConnectIP(chip::Controller::DeviceCommissioner*, char const*, uint32_t, chip::NodeId)
+    (devCtrl=0xd28540, peerAddrStr=0xfffff467ace0 "192.168.50.5", setupPINCode=20202021, nodeid=1) at ../../src/controller/python/ChipDeviceController-ScriptBinding.cpp:234
+#2  0x0000fffff7639148 in  () at /lib/aarch64-linux-gnu/libffi.so.8
+#3  0x0000fffff7638750 in  () at /lib/aarch64-linux-gnu/libffi.so.8
+#4  0x0000fffff7665a44 in  () at /usr/lib/python3.9/lib-dynload/_ctypes.cpython-39-aarch64-linux-gnu.so
+#5  0x0000fffff7664c7c in  () at /usr/lib/python3.9/lib-dynload/_ctypes.cpython-39-aarch64-linux-gnu.so
+#6  0x00000000004a54f0 in _PyObject_MakeTpCall ()
+#7  0x000000000049cb10 in _PyEval_EvalFrameDefault ()
+#8  0x0000000000496d1c in  ()
+#9  0x00000000004b1eb0 in _PyFunction_Vectorcall ()
+#10 0x0000000000498264 in _PyEval_EvalFrameDefault ()
+#11 0x00000000004b1cb8 in _PyFunction_Vectorcall ()
+#12 0x0000000000498418 in _PyEval_EvalFrameDefault ()
+#13 0x0000000000496d1c in  ()
+#14 0x00000000004b1eb0 in _PyFunction_Vectorcall ()
+#15 0x0000000000498418 in _PyEval_EvalFrameDefault ()
+#16 0x00000000004b1cb8 in _PyFunction_Vectorcall ()
+#17 0x00000000004c6bc8 in  ()
+#18 0x0000000000498264 in _PyEval_EvalFrameDefault ()
+#19 0x00000000004b1cb8 in _PyFunction_Vectorcall ()
+#20 0x0000000000498418 in _PyEval_EvalFrameDefault ()
+#21 0x00000000004966f8 in  ()
+#22 0x00000000004b1f18 in _PyFunction_Vectorcall ()
+#23 0x0000000000498418 in _PyEval_EvalFrameDefault ()
+#24 0x00000000004b1cb8 in _PyFunction_Vectorcall ()
+#25 0x0000000000498264 in _PyEval_EvalFrameDefault ()
+#26 0x00000000004966f8 in  ()
+#27 0x0000000000496490 in _PyEval_EvalCodeWithName ()
+#28 0x0000000000595b7c in PyEval_EvalCode ()
+#29 0x00000000005c6a5c in  ()
+#30 0x00000000005c0a70 in  ()
+#31 0x00000000005c69a8 in  ()
+#32 0x00000000005c6148 in PyRun_SimpleFileExFlags ()
+#33 0x00000000005b60bc in Py_RunMain ()
+#34 0x0000000000585a08 in Py_BytesMain ()
+#35 0x0000fffff7d0c9d4 in __libc_start_main (main=
+    0x5858fc <_start+60>, argc=2, argv=0xfffffffff498, init=<optimized out>, fini=<optimized out>, rtld_fini=<optimized out>, stack_end=<optimized out>) at ../csu/libc-start.c:332
+#36 0x00000000005858f8 in _start ()
+(gdb)
+```
+
+The frame #0 and frame #1 are the function frame in the CHIP C++ library, the
+other frames lives in the Python intepreter so you can ignore it.

--- a/src/controller/python/ADVANCED_USAGE.md
+++ b/src/controller/python/ADVANCED_USAGE.md
@@ -1,63 +1,61 @@
 # Python CHIP Device Controller - Advanced usage
 
-## BLE Virtualization on Linux (Optional)
+This document extends the [basic documentation](README.md) with the useful information when developing Python CHIP controller tool or Matter accessories on Linux.
 
-If you would like to setup virtual BLE central and peripheral in the same
-machine, then follow below steps:
+## Bluetooth LE virtualization on Linux
 
-```
-cd third_party/bluez/repo
-./bootstrap
-third_party/bluez/repo/configure --prefix=/usr --mandir=/usr/share/man --sysconfdir=/etc --localstatedir=/var --enable-experimental --with-systemdsystemunitdir=/lib/systemd/system --with-systemduserunitdir=/usr/lib/systemd --enable-deprecated --enable-testing --enable-tools
-make
-```
+Commissioning over Bluetooth LE can be tested even if the controller and the device run on the same machine. To that end, you will need to set up two virtual interfaces working as Bluetooth LE central and peripheral, respectively.
 
-Note: You also need to install several packages on RPi if you want to build
-bluez
+1. Build `bluez` project from sources by completing the following steps:
 
-```
-sudo apt-get install libtool m4 automake autotools-dev libudev-dev libical-dev libreadline-dev
-```
+   ```
+   sudo apt-get update
+   sudo apt-get install libtool m4 automake autotools-dev libudev-dev libical-dev libreadline-dev
 
-Run bluetoothd:
+   cd third_party/bluez/repo
+   ./bootstrap
+   third_party/bluez/repo/configure --prefix=/usr --mandir=/usr/share/man --sysconfdir=/etc --localstatedir=/var --enable-experimental --with-systemdsystemunitdir=/lib/systemd/system --with-systemduserunitdir=/usr/lib/systemd --enable-deprecated --enable-testing --enable-tools
+   make
+   ```
 
-```
-sudo third_party/bluez/repo/src/bluetoothd --experimental --debug &
-```
+2. Run bluetoothd:
 
-Bring up two virtual ble interface:
+   ```
+   sudo third_party/bluez/repo/src/bluetoothd --experimental --debug &
+   ```
 
-```
-sudo third_party/bluez/repo/emulator/btvirt -L -l2
-```
+3. Bring up two virtual Bluetooth LE interfaces:
 
-You can find the virtual interface by `hciconfig` command:
+   ```
+   sudo third_party/bluez/repo/emulator/btvirt -L -l2
+   ```
 
-```
-$ hciconfig
+   You can find the virtual interface by running `hciconfig` command:
 
-hci2:	Type: Primary  Bus: Virtual
-	BD Address: 00:AA:01:01:00:24  ACL MTU: 192:1  SCO MTU: 0:0
-	UP RUNNING
-	RX bytes:0 acl:95 sco:0 events:205 errors:0
-	TX bytes:2691 acl:95 sco:0 commands:98 errors:0
+   ```
+   $ hciconfig
 
-hci1:	Type: Primary  Bus: Virtual
-	BD Address: 00:AA:01:00:00:23  ACL MTU: 192:1  SCO MTU: 0:0
-	UP RUNNING
-	RX bytes:0 acl:95 sco:0 events:208 errors:0
-	TX bytes:3488 acl:95 sco:0 commands:110 errors:0
-```
+   hci2:	Type: Primary  Bus: Virtual
+      BD Address: 00:AA:01:01:00:24  ACL MTU: 192:1  SCO MTU: 0:0
+      UP RUNNING
+      RX bytes:0 acl:95 sco:0 events:205 errors:0
+      TX bytes:2691 acl:95 sco:0 commands:98 errors:0
 
-Then you can choose the adapter to use in command line arguments of the device
-controller:
+   hci1:	Type: Primary  Bus: Virtual
+      BD Address: 00:AA:01:00:00:23  ACL MTU: 192:1  SCO MTU: 0:0
+      UP RUNNING
+      RX bytes:0 acl:95 sco:0 events:208 errors:0
+      TX bytes:3488 acl:95 sco:0 commands:110 errors:0
+   ```
 
-For example, add `--bluetooth-adapter=hci2` to use the virtual interface `hci2`
-listed above.
+4. Run the Python CHIP Controller with Bluetooth LE adapter defined from a command line:
 
-```
-chip-device-ctrl --bluetooth-adapter=hci2
-```
+   For example, add `--bluetooth-adapter=hci2` to use the virtual interface `hci2`
+   listed above.
+
+   ```
+   chip-device-ctrl --bluetooth-adapter=hci2
+   ```
 
 ## Debugging with gdb
 
@@ -65,7 +63,7 @@ You can run the chip-device-ctrl under GDB for debugging, however, since the
 CHIP core support library is a dynamic library, you cannot read the symbols
 unless it is fully loaded.
 
-The following block is a example debug session using GDB
+The following block is a example debug session using GDB:
 
 ```
 # GDB cannot run scripts directly
@@ -93,11 +91,10 @@ Reading symbols from python3...
 ```
 
 The Python will create lots of threads due to main loop, so you may want to
-supress thread related outputs first by `set print thread-events off`
+supress thread related outputs first by running the following command:
 
 ```
 (gdb) set print thread-events off
-(gdb)
 ```
 
 We cannot set breakpoints here, since the GDB knows nothing about the CHIP
@@ -230,5 +227,5 @@ then you can use `bt` (for `backtrace`) to see the backtrace of the call stack.
 (gdb)
 ```
 
-The frame #0 and frame #1 are the function frame in the CHIP C++ library, the
-other frames lives in the Python intepreter so you can ignore it.
+The frame #0 and frame #1 are the function frames in the CHIP C++ library, the
+other frames live in the Python intepreter so you can ignore it.

--- a/src/controller/python/README.md
+++ b/src/controller/python/README.md
@@ -1,212 +1,330 @@
-# CHIP Device Controller - Python Binding & Command line interface
+# Python CHIP Device Controller
 
 ## Overview
 
-Chip Device Controller is a general library to control devices and manage
-commissioner functionality, it has Python, Java (for Android) and ObjC (for iOS)
-bindings for building tests and CHIP mobile applications. This document will
-focus on its python binding interface on Linux and mac os.
+The Python CHIP controller allows to commission the Matter device into
+the network as well as communicate with it using the Zigbee Cluster Library (ZCL) messages. The tool utilizes the generic [Chip Device Controller](../) library.
+
+Below instruction presents how to build and test Python CHIP controller. The sample test flow may vary depending on the application clusters implemented on the device side.
+
+To learn more about advanced usage of the tool, check [extended documentation](ADVANCED_USAGE.md).
 
 ## Checkout / Build / Install
 
-> Note: The CHIP can be built on Linux (amd64 / aarch64) and macOS
+Before you can use the Python controller, you must compile it from the source on Linux (amd64 / aarch64) or macOS.
 
-1. Clone Project CHIP repo.
+> To ensure compatibility, build the Python CHIP controller and the Matter device from the same revision of the connectedhomeip repository.
 
-```
-git clone https://github.com/project-chip/connectedhomeip.git
-```
+To build and run the Python CHIP controller:
 
-2. Build the CHIP python package
+1. Install all necessary packages and prepare the build system. For more details, see the [BUILDING.md](/docs/BUILDING.md) documentation.
 
-Follow [BUILDING.md](/docs/BUILDING.md) to setup CHIP on your platform.
+   ```
+   sudo apt-get update
+   sudo apt-get upgrade
 
-Genrally, once build dependencies are satisfied you can build the `python`
-target.
+   sudo apt-get install git gcc g++ python pkg-config libssl-dev libdbus-1-dev libglib2.0-dev libavahi-client-dev ninja-build python3-venv python3-dev python3-pip unzip libgirepository1.0-dev libcairo2-dev bluez
+   ```
 
-Use `scripts/build_python.sh` or run something equivalent to:
+   If the Python CHIP controller is built on a Raspberry Pi, install additional packages and reboot the device:
 
-```sh
-gn gen out/python_lib
-ninja -C out/python_lib python
-```
+   ```
+   sudo apt-get install pi-bluetooth
+   sudo reboot
+   ```
 
-3. Install Chip Device Controller
+2. Clone the Project CHIP repository.
 
-> Note: Python device controller is not versioned, so you need to uninstall the
-> old device controller before install the new one.
+   ```
+   git clone https://github.com/project-chip/connectedhomeip.git
+   ```
 
-> It is recommended to setup a separate clean virtual environment The
-> `scripts/build_python.sh` script sets up a python environment and installs the
-> WHL file.
+3. Enter the `connectedhomeip` directory.
 
-```sh
-virtualenv out/python_env --clear
-source out/python_env/bin/activate
-pip install out/python_lib/controller/python/chip*.whl
-```
+   ```
+   cd connectedhomeip
+   ```
 
-The WHL file installation will:
+4. Initialize the git submodules.
 
--   Install the 'chip' module
--   create a `ENV/bin/chip-device-ctrl` script that provides an interactive
-    shell for the chip library
+   ```
+   git submodule update --init
+   ```
 
-## BLE Virtualization on Linux (Optional)
+5. Build and install the Python CHIP controller.
 
-If we would like to setup virtual BLE central and peripheral in the same
-machine, then Bluez setup
+   ```
+   scripts/build_python.sh -m platform
+   ```
 
-```
-cd third_party/bluez/repo
-./bootstrap
-third_party/bluez/repo/configure --prefix=/usr --mandir=/usr/share/man --sysconfdir=/etc --localstatedir=/var --enable-experimental --with-systemdsystemunitdir=/lib/systemd/system --with-systemduserunitdir=/usr/lib/systemd --enable-deprecated --enable-testing --enable-tools
-make
-```
+   > Note: To get more details about available build configurations, run the following command:
+   > ```scripts/build_python.sh --help```
 
-Note: You also need to install several packages on RPi if you want to build
-bluez
+6. Activate the Python virtual environment.
 
-```
-sudo apt-get install libtool m4 automake autotools-dev libudev-dev libical-dev libreadline-dev
-```
+   ```
+   source out/python_env/bin/activate
+   ```
 
-Run bluetoothd:
+7. Run the Python CHIP controller.
 
-```
-sudo third_party/bluez/repo/src/bluetoothd --experimental --debug &
-```
+   > Running as root is necessary to obtain access to the Bluetooth interface.
 
-Bring up two virtual ble interface:
+   ```
+   sudo out/python_env/bin/chip-device-ctrl
+   ```
 
-```
-sudo third_party/bluez/repo/emulator/btvirt -L -l2
-```
+   You can also select the Bluetooth LE interface using command line argument:
 
-You can find the virtual interface by `hciconfig` command:
+   ```
+   sudo out/python_env/bin/chip-device-ctrl --bluetooth-adapter=hci2
+   ```
 
-```
-$ hciconfig
+## Working with Python CHIP Controller
 
-hci2:	Type: Primary  Bus: Virtual
-	BD Address: 00:AA:01:01:00:24  ACL MTU: 192:1  SCO MTU: 0:0
-	UP RUNNING
-	RX bytes:0 acl:95 sco:0 events:205 errors:0
-	TX bytes:2691 acl:95 sco:0 commands:98 errors:0
+### 1. Prepare the Matter accessory.
 
-hci1:	Type: Primary  Bus: Virtual
-	BD Address: 00:AA:01:00:00:23  ACL MTU: 192:1  SCO MTU: 0:0
-	UP RUNNING
-	RX bytes:0 acl:95 sco:0 events:208 errors:0
-	TX bytes:3488 acl:95 sco:0 commands:110 errors:0
-```
+In this tutorial, the [Matter: Light Bulb](/examples/lighting-app) example with Bluetooth LE commissioning will be used, but similar steps can be executed with the rest of the examples. Check [Matter examples](/examples) for the list of available samples.
 
-Then you can choose the adapter to use in command line arguments of the device
-controller:
+Build and program the device with the Matter accessory firmware by following the example's documentation, for example [nRF Connect Lighting Example Application](/examples/lightigng-app/nrfconnect).
 
-For example, add `--bluetooth-adapter=hci2` to use the virtual interface `hci2`
-listed above.
+### 2. Enable Bluetooth LE advertising on Matter accessory device.
 
-```
-chip-device-ctrl --bluetooth-adapter=hci2
-```
+Some examples are configured to advertise automatically on boot, others require physical trigger like pushing the button. Follow the Matter accessory example's documentation to learn how Bluetooth LE advertising is enabled.
 
-## Usage / BLE Secure Session Establishment
+### 3. Discover Matter accessory device over Bluetooth LE
 
-1. Run CHIP Device Controller
-
-> Running as root via `sudo` to ensure permissions to interface with the
-> bluetooth adapter.
-
-```
-sudo chip-device-ctrl
-```
-
-or select the bluetooth interface by command line arguments.
-
-```
-sudo chip-device-ctrl --bluetooth-adapter=hci2
-```
-
-2. Scan BLE devices
+An uncommissioned accessory device advertises over Bluetooth LE. Run the following command to scan all advertised Matter devices:
 
 ```
 chip-device-ctrl > ble-scan
-2021-01-19 02:27:23,653 ChipBLEMgr   INFO     scanning started
-2021-01-19 02:27:25,144 ChipBLEMgr   INFO     Name            = CHIP-1383
-2021-01-19 02:27:25,144 ChipBLEMgr   INFO     ID              = ae0125dc-e621-3e05-9166-70ca7ea07985
-2021-01-19 02:27:25,146 ChipBLEMgr   INFO     RSSI            = -32
-2021-01-19 02:27:25,147 ChipBLEMgr   INFO     Address         = DC:A6:32:A5:4C:56
-2021-01-19 02:27:25,151 ChipBLEMgr   INFO     Pairing State   = 0
-2021-01-19 02:27:25,151 ChipBLEMgr   INFO     Discriminator   = 1383
-2021-01-19 02:27:25,152 ChipBLEMgr   INFO     Vendor Id       = 9050
-2021-01-19 02:27:25,152 ChipBLEMgr   INFO     Product Id      = 65279
-2021-01-19 02:27:25,155 ChipBLEMgr   INFO     Adv UUID        = 0000fff6-0000-1000-8000-00805f9b34fb
-2021-01-19 02:27:25,156 ChipBLEMgr   INFO     Adv Data        = 0067055a23fffe
-2021-01-19 02:27:27,257 ChipBLEMgr   INFO
-2021-01-19 02:27:34,213 ChipBLEMgr   INFO     scanning stopped
-Connect to BLE device
 ```
 
-3.  Set wifi credential
+### 4. Connect to Matter accessory device over Bluetooth LE
 
-> Note: This command will be deprerated after the network provisioning cluster
-> is ready.
-
-```
-chip-device-ctrl > set-pairing-wifi-credential TestAP TestPassword
-```
-
-4.  Connect to device using setup pin code
+The controller uses a 12-bit value to discern between multiple commissionable device advertisements which is called **Discriminator**. The Matter accessory verifies the Controller by checking if the setup code is in his possession. You can find those values in the logging terminal of the device (e.g. UART), as listed below.
 
 ```
-chip-device-ctrl > connect -ble 1383 20202021
+I: 254 [DL]Device Configuration:
+I: 257 [DL] Serial Number: TEST_SN
+I: 260 [DL] Vendor Id: 9050 (0x235A)
+I: 263 [DL] Product Id: 20043 (0x4E4B)
+I: 267 [DL] Product Revision: 1
+I: 270 [DL] Setup Pin Code: 20202021
+I: 273 [DL] Setup Discriminator: 3840 (0xF00)
+I: 278 [DL] Manufacturing Date: (not set)
+I: 281 [DL] Device Type: 65535 (0xFFFF)
 ```
 
-## Thread provisioning
-
-1. Configure Thread border router. For example, follow
-   [Setup OpenThread Border Router on Raspberry Pi / ubuntu](../../../docs/guides/openthread_border_router_pi.md)
-   instruction to configure OpenThread Border Router on a Linux workstation.
-
-2. Run CHIP Device Controller
+Run the following command to establish secure connection over Bluetooth LE, with the following assumptions for the Matter accessory device:
+ - The discriminator of the device is 3840
+ - The setup pin code of the device is 20202021
+ - The temporary Node ID is 1234
 
 ```
-sudo chip-device-ctrl
+chip-device-ctrl > connect -ble 3840 20202021 1234
 ```
 
-3. Set Thread credentials
+You may skip providing the last parameter which is a Node ID. In such case, the controller will randomly assign it. However, note the Node ID down, because it is required later in the configuration process.
+
+At the end of the secure connection establishment, the Python controller will indicate this by printing the following log:
 
 ```
-set-pairing-thread-credential <channel> <pan id[HEX]> <master_key>
+Secure Session to Device Established
 ```
 
-4. BLE Connect to the device
+This means that the PASE (Password-Authenticated Session Establishment) session using SPAKE2+ protocol is completed.
+
+### 5. Commission Matter accessory to the underlying network
+
+One of the commissioning steps is Network Commissioning. The main goal of this step is to configure network interface, such as Thread or Wifi, and to provide network credentials.
+
+#### Commissioning of Thread device
+
+1. Fetch and store the current Active Operational Dataset and Extended PAN ID from the Thread Border Router.
+
+   Depending if Thread Border Router is running on Docker or natively on Raspberry Pi, execute the following commands:
+
+   For Docker:
+   ```
+   sudo docker exec -it otbr sh -c "sudo ot-ctl dataset active -x"
+   0e080000000000010000000300001335060004001fffe002084fe76e9a8b5edaf50708fde46f999f0698e20510d47f5027a414ffeebaefa92285cc84fa030f4f70656e5468726561642d653439630102e49c0410b92f8c7fbb4f9f3e08492ee3915fbd2f0c0402a0fff8
+   Done
+
+   sudo docker exec -it otbr sh -c "sudo ot-ctl dataset extpanid”
+   4fe76e9a8b5edaf5
+   Done
+   ```
+
+   For native installation:
+
+   ```
+   sudo ot-ctl dataset active -x
+   0e080000000000010000000300001335060004001fffe002084fe76e9a8b5edaf50708fde46f999f0698e20510d47f5027a414ffeebaefa92285cc84fa030f4f70656e5468726561642d653439630102e49c0410b92f8c7fbb4f9f3e08492ee3915fbd2f0c0402a0fff8
+   Done
+
+   sudo ot-ctl dataset extpanid
+   4fe76e9a8b5edaf5
+   Done
+   ```
+
+   Matter specifiction does not define how the Thread or Wi-Fi credentials are obtained by Controller. For example, for Thread, instead of fetching datasets directly from the Thread Border Router, you may also use different out-of-band method.
+
+2. Inject the previously obtained Active Operational Dataset as hex-encoded value using ZCL Network Commissioning cluster.
+
+   > Each ZCL command has a following format:
+      `zcl <Cluster> <Command> <Node Id> <Endpoint Id> <Group Id> [arguments]`
+   >
+   > Use the `zcl ? <Cluster>` command to list all available commands for given ZCL cluster.
+
+   ```
+   chip-device-ctrl > zcl NetworkCommissioning AddThreadNetwork 1234 0 0 operationalDataset=hex:0e080000000000010000000300001335060004001fffe002084fe76e9a8b5edaf50708fde46f999f0698e20510d47f5027a414ffeebaefa92285cc84fa030f4f70656e5468726561642d653439630102e49c0410b92f8c7fbb4f9f3e08492ee3915fbd2f0c0402a0fff8 breadcrumb=0 timeoutMs=3000
+   ```
+
+3. Enable Thread interface in the device by executing the following command with `networkID` equal to Extended PAN Id of the Thread network.
+
+   ```
+   chip-device-ctrl > zcl NetworkCommissioning EnableNetwork 1234 0 0 networkID=hex:4fe76e9a8b5edaf5 breadcrumb=0 timeoutMs=3000
+   ```
+
+#### Commissioning of Wi-Fi device
+
+1. Assuming your Wi-Fi SSID is *TESTSSID*, and your Wi-Fi password is *P455W4RD*, inject the credentials to the device by excuting the following command.
+
+   ```
+   chip-device-ctrl > zcl NetworkCommissioning AddWiFiNetwork 1234 0 0 ssid=str:TESTSSID credentials=str:P455W4RD breadcrumb=0 timeoutMs=1000
+   ```
+
+2. Enable Wi-Fi interface in the device by executing the following command:
+
+   ```
+   chip-device-ctrl > zcl NetworkCommissioning EnableNetwork 1234 0 0 networkID=str:TESTSSID breadcrumb=0 timeoutMs=1000
+   ```
+
+### 6. Close Bluetooth LE connection.
+
+After Matter accessory was provisioned with Thread and/or Wi-Fi credentials, the commissioning process is finished. Python CHIP controller will now use only IPv6 traffic to reach the device, so Bluetooth LE connection can be closed.
 
 ```
-connect -ble <discriminator> <setup pin code> [<nodeid>]
+chip-device-ctrl > close-ble
 ```
 
-## IP Secure Session Establishment
+### 7. Discover IPv6 address of the Matter accessory.
 
-1. Run CHIP Device Controller
+The Matter controller needs to discover IPv6 address of the node that it previously commissioned. For Thread, the Matter accessory uses SRP (Service Registration Protocol) to register its presence on the Thread Border Router’s SRP Server, for Wi-Fi or Ethernet devices, the mDNS (Multicast Domain Name System) protocol is used instead.
 
-```
-chip-device-ctrl
-```
-
-> Note: SUDO is not required when use IP to connect device.
-
-2. Connect to device using setup pin code
+Run the following command, assuming that:
+ - The Fabric ID of the device is 5544332211
+ - The Node ID is 1234
 
 ```
-chip-device-ctrl > connect -ip <Device IP Address> 20202021
+chip-device-ctrl > resolve 5544332211 1234
 ```
 
-## Commands
+After successful resolution, you should see the log indicating that node address has been updated. The IPv6 address of the device will be cached in the controller for later usage.
 
-**`[L]`** = Linux only / **`[D]`** = Deprecated / **`[W]`** = WIP / **`[T]`** =
-For testing
+### 8. Control application ZCL clusters.
+
+For Light Bulb example, execute the following command to toggle the LED state:
+
+```
+chip-device-ctrl > zcl OnOff Toggle 1234 1 0
+```
+
+To change the brightness of the LED, use the following command, with level changed to the value between 0 and 255.
+
+```
+chip-device-ctrl > zcl LevelControl MoveToLevel 1234 1 0 level=50
+```
+
+### 9. Read basic information out of the accessory.
+
+Every Matter accessory device supports Basic Cluster which maintains collection of attributes that a controller may obtain from a device, such as the vendor name, the product name, or software version. Use `zclread` command to read those values out of the device:
+
+```
+chip-device-ctrl > zclread Basic VendorName 1234 1 0
+chip-device-ctrl > zclread Basic ProductName 1234 1 0
+chip-device-ctrl > zclread Basic SoftwareVersion 1234 1 0
+```
+
+## List of commands
+
+### `ble-adapter-print`
+
+Print the available Bluetooth adapters on device. Takes no arguments.
+
+```
+chip-device-ctrl > ble-adapter-print
+2021-03-04 16:09:40,930 ChipBLEMgr   INFO     AdapterName: hci0   AdapterAddress: 00:AA:01:00:00:23
+```
+
+### `ble-debug-log`
+
+Enable Bluetooth LE debug logs.
+
+```
+chip-device-ctrl > ble-debug-log 1
+```
+
+### `ble-scan [-t <timeout>] [identifier]`
+
+Start a ble-scan action for searching valid CHIP devices over BLE [for at most
+*timeout* seconds], stop when device matching the identifier or timeout.
+
+```
+chip-device-ctrl > ble-scan
+2021-05-29 22:28:05,461 ChipBLEMgr   INFO     scanning started
+2021-05-29 22:28:07,206 ChipBLEMgr   INFO     Name            = ChipLight
+2021-05-29 22:28:07,206 ChipBLEMgr   INFO     ID              = f016e23d-0d00-35d5-93e7-588acdbc7e54
+2021-05-29 22:28:07,207 ChipBLEMgr   INFO     RSSI            = -79
+2021-05-29 22:28:07,207 ChipBLEMgr   INFO     Address         = E0:4D:84:3C:BB:C3
+2021-05-29 22:28:07,209 ChipBLEMgr   INFO     Pairing State   = 0
+2021-05-29 22:28:07,209 ChipBLEMgr   INFO     Discriminator   = 3840
+2021-05-29 22:28:07,209 ChipBLEMgr   INFO     Vendor Id       = 9050
+2021-05-29 22:28:07,209 ChipBLEMgr   INFO     Product Id      = 20044
+2021-05-29 22:28:07,210 ChipBLEMgr   INFO     Adv UUID        = 0000fff6-0000-1000-8000-00805f9b34fb
+2021-05-29 22:28:07,210 ChipBLEMgr   INFO     Adv Data        = 00000f5a234c4e
+2021-05-29 22:28:07,210 ChipBLEMgr   INFO    
+2021-05-29 22:28:16,246 ChipBLEMgr   INFO     scanning stopped
+```
+
+### `connect -ip <address> <SetUpPinCode> [<nodeid>]`
+
+Do key exchange and establish a secure session between controller and device
+using IP transport.
+
+The node id will be used by controller to distinguish multiple devices. This
+does not match the spec and will be removed later. The nodeid will not be
+persisted by controller / device.
+
+If no nodeid given, a random node id will be used.
+
+### `connect -ble <discriminator> <SetUpPinCode> [<nodeid>]`
+
+Do key exchange and establish a secure session between controller and device
+using BLE transport.
+
+The node id will be used by controller to distinguish multiple devices. This
+does not match the spec and will be removed later. The nodeid will not be
+persisted by controller / device.
+
+If no nodeid given, a random node id will be used.
+
+### `discover`
+
+Discover available Matter accessory devices.
+
+```
+chip-device-ctrl > discover -all
+```
+
+### `resolve <fabric_id> <node_id>`
+
+Resolve DNS-SD name corresponding with the given fabric and node IDs and update address of the node in the device controller.
+
+```
+chip-device-ctrl > resolve 5544332211 1234
+```
 
 ### `setup-payload parse-manual <manual-pairing-code>`
 
@@ -238,74 +356,26 @@ Discriminator: 3840
 SetUpPINCode: 20202021
 ```
 
-### **`[L]`** `ble-adapter-print`
+### `zcl <Cluster> <Command> <NodeId> <EndpointId> <GroupId> [arguments]`
 
-Print the available Bluetooth adapters on device. Takes no arguments.
-
-```
-chip-device-ctrl > ble-adapter-print
-2021-03-04 16:09:40,930 ChipBLEMgr   INFO     AdapterName: hci0   AdapterAddress: 00:AA:01:00:00:23
-```
-
-### **`[D]`** `ble-adapter-select <address>`
-
-Select the Bluetooth adapter for device controller, takes adapter MAC address as
-argument. This command only affects `ble-scan` command.
+Send a ZCL command the device. For example:
 
 ```
-chip-device-ctrl > ble-adapter-select DC:A6:32:9E:2E:A7
-(no output)
+chip-device-ctrl > zcl LevelControl MoveWithOnOff 12344321 1 0 moveMode=1 rate=2
 ```
 
-### `ble-scan [-t <timeout>] [identifier]`
+**Format of arguments**
 
-Start a ble-scan action for searching valid CHIP devices over BLE [for at most
-*timeout* seconds], stop when device matching the identifier or timeout.
+For any integer and char string (null terminated) types, just use `key=value`,
+for example: `rate=2`, `string=123`, `string_2="123 456"`
 
-```
-chip-device-ctrl > ble-scan
-2021-01-19 02:27:23,653 ChipBLEMgr   INFO     scanning started
-2021-01-19 02:27:25,144 ChipBLEMgr   INFO     Name            = CHIP-1383
-2021-01-19 02:27:25,144 ChipBLEMgr   INFO     ID              = ae0125dc-e621-3e05-9166-70ca7ea07985
-2021-01-19 02:27:25,146 ChipBLEMgr   INFO     RSSI            = -32
-2021-01-19 02:27:25,147 ChipBLEMgr   INFO     Address         = DC:A6:32:A5:4C:56
-2021-01-19 02:27:25,151 ChipBLEMgr   INFO     Pairing State   = 0
-2021-01-19 02:27:25,151 ChipBLEMgr   INFO     Discriminator   = 1383
-2021-01-19 02:27:25,152 ChipBLEMgr   INFO     Vendor Id       = 9050
-2021-01-19 02:27:25,152 ChipBLEMgr   INFO     Product Id      = 65279
-2021-01-19 02:27:25,155 ChipBLEMgr   INFO     Adv UUID        = 0000fff6-0000-1000-8000-00805f9b34fb
-2021-01-19 02:27:25,156 ChipBLEMgr   INFO     Adv Data        = 0067055a23fffe
-2021-01-19 02:27:27,257 ChipBLEMgr   INFO
-2021-01-19 02:27:34,213 ChipBLEMgr   INFO     scanning stopped
-```
+For byte string type, use `key=encoding:value`, currectly, we support `str` and
+`hex` encoding, the `str` encoding will encode a NULL terminated string. For
+example, `networkId=hex:0123456789abcdef` (for
+`[0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef]`), `ssid=str:Test` (for
+`['T', 'e', 's', 't', 0x00]`).
 
-### `connect -ip <address> <SetUpPinCode> [<nodeid>]`
-
-Do key exchange and establish a secure session between controller and device
-using IP transport.
-
-The node id will be used by controller to distinguish multiple devices. This
-does not match the spec and will be removed later. The nodeid will not be
-persisted by controller / device.
-
-If no nodeid given, a random node id will be used.
-
-### `connect -ble <discriminator> <SetUpPinCode> [<nodeid>]`
-
-Do key exchange and establish a secure session between controller and device
-using BLE transport.
-
-The node id will be used by controller to distinguish multiple devices. This
-does not match the spec and will be removed later. The nodeid will not be
-persisted by controller / device.
-
-If no nodeid given, a random node id will be used.
-
-### **`[W]`** `zcl`
-
-Sending ZCL commands.
-
-#### `zcl ?`
+### `zcl ?`
 
 List available clusters.
 
@@ -314,9 +384,9 @@ chip-device-ctrl > zcl ?
 dict_keys(['BarrierControl', 'Basic', 'ColorControl', 'DoorLock', 'Groups', 'IasZone', 'Identify', 'LevelControl', 'NetworkProvisioning', 'OnOff', 'Scenes', 'TemperatureMeasurement'])
 ```
 
-#### `zcl ? <Cluster>`
+### `zcl ? <Cluster>`
 
-List available commands in cluster.
+List available commands in cluster. For example, for *LevlControl* cluster:
 
 ```
 chip-device-ctrl > zcl ? LevelControl
@@ -338,260 +408,18 @@ StopWithOnOff
   <no arguments>
 ```
 
-#### `zcl <Cluster> <Command> <NodeId> <EndpointId> <GroupId> [arguments]`
+### `zclread <Cluster> <Attribute> <NodeId> <EndpointId> <GroupId> [arguments]`
 
-Send a ZCL command to `EndpointId` on device (`NodeId`).
-
-Example:
+Read the value of ZCL attribute. For example:
 
 ```
-chip-device-ctrl > zcl LevelControl MoveWithOnOff 12344321 1 0 moveMode=1 rate=2
+chip-device-ctrl > zclread Basic VendorName 1234 1 0
 ```
 
-**Format of arguments**
+#### `zclconfigure <Cluster> <Attribute> <Nodeid> <Endpoint> <MinInterval> <MaxInterval> <Change>`
 
-For any integer and char string (null terminated) types, just use `key=value`,
-for example: `rate=2`, `string=123`, `string_2="123 456"`
-
-For byte string type, use `key=encoding:value`, currectly, we support `str` and
-`hex` encoding, the `str` encoding will encode a NULL terminated string. For
-example, `networkId=hex:0123456789abcdef` (for
-`[0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef]`), `ssid=str:Test` (for
-`['T', 'e', 's', 't', 0x00]`).
-
-## Example Commissioning flow over
-
--   Assuming your WiFi ssid is `TESTSSID`, and your WiFi password is `P455W4RD`.
-
--   Assuming your Thread network has the following operational dataset (the
-    extended pan id of this network is `577c1f5384d9e909`, thus the network id
-    for this network is also `577c1f5384d9e909`):
-
-    ```
-    0e 08 0000000000010000
-    00 03 000014
-    35 06 0004001fffe0
-    02 08 577c1f5384d9e909
-    07 08 fdca4e253816ae9d
-    05 10 bb53ac7bf2133f0f686759ad9969255c
-    03 0f 4f70656e5468726561642d31343937
-    01 02 1497
-    04 10 420111ea791a892d28e3160f20eea396
-    0c 03 0000ff
-    ```
-
--   Assuming your device is on the same network, with IP address 192.168.0.1
-
--   The setup pincode is 20202021
-
--   You set the temporary node id to 4546
-
--   The discriminator of the device is 2333
-
-> Establish PASE session over BLE
->
-> ```
-> chip-device-ctrl > connect -ble 2333 20202021 4546
-> ```
-
-> Establish PASE session over IP
->
-> ```
-> chip-device-ctrl > connect -ip 192.168.0.1 20202021 4546
-> ```
-
-> Skip this part if your device does not support WiFi.
->
-> ```
-> chip-device-ctrl > zcl NetworkCommissioning AddWiFiNetwork 4546 0 0 ssid=str:TESTSSID credentials=str:P455W4RD breadcrumb=0 timeoutMs=1000
->
-> chip-device-ctrl > zcl NetworkCommissioning EnableNetwork 4546 0 0 networkID=str:TESTSSID breadcrumb=0 timeoutMs=1000
-> ```
-
-> Skip this part if your device does not support Thread.
->
-> ```
-> chip-device-ctrl > zcl NetworkCommissioning AddThreadNetwork 4546 0 0 operationalDataset=hex:0e080000000000010000000300001435060004001fffe00208577c1f5384d9e9090708fdca4e253816ae9d0510bb53ac7bf2133f0f686759ad9969255c030f4f70656e5468726561642d31343937010214970410420111ea791a892d28e3160f20eea3960c030000ff breadcrumb=0 timeoutMs=1000
->
-> chip-device-ctrl > zcl NetworkCommissioning EnableNetwork 4546 0 0 networkID=hex:577c1f5384d9e909 breadcrumb=0 timeoutMs=1000
-> ```
-
-> If you are using BLE connection, release BLE connection
->
-> ```
-> chip-device-ctrl > close-ble
-> ```
-
-## Debugging with gdb
-
-You can run the chip-device-ctrl under GDB for debugging, however, since the
-CHIP core support library is a dynamic library, you cannot read the symbols
-unless it is fully loaded.
-
-The following block is a example debug session using GDB
+Configure ZCL attribute reporting settings. For example:
 
 ```
-# GDB cannot run scripts directly
-# so you need to run Python3 with the path of device controller
-# Here, we use the feature from bash to get the path of chip-device-ctrl without typing it.
-$ gdb --args python3 `which chip-device-ctrl`
-GNU gdb (Ubuntu 10.1-2ubuntu2) 10.1.90.20210411-git
-Copyright (C) 2021 Free Software Foundation, Inc.
-License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
-This is free software: you are free to change and redistribute it.
-There is NO WARRANTY, to the extent permitted by law.
-Type "show copying" and "show warranty" for details.
-This GDB was configured as "aarch64-linux-gnu".
-Type "show configuration" for configuration details.
-For bug reporting instructions, please see:
-<https://www.gnu.org/software/gdb/bugs/>.
-Find the GDB manual and other documentation resources online at:
-    <http://www.gnu.org/software/gdb/documentation/>.
-
-For help, type "help".
-Type "apropos word" to search for commands related to "word"...
-Reading symbols from python3...
-(No debugging symbols found in python3)
-(gdb)
+chip-device-ctrl > zclconfigure OccupancySensing Occupancy 1234 1 0 1000 2000 1
 ```
-
-The Python will create lots of threads due to main loop, so you may want to
-supress thread related outputs first by `set print thread-events off`
-
-```
-(gdb) set print thread-events off
-(gdb)
-```
-
-We cannot set breakpoints here, since the GDB knows nothing about the CHIP
-library, let run the CHIP device controller first.
-
-```
-(gdb) run
-Starting program: /usr/bin/python3 /home/ubuntu/.local/bin/chip-device-ctrl
-[Thread debugging using libthread_db enabled]
-Using host libthread_db library "/lib/aarch64-linux-gnu/libthread_db.so.1".
-CHIP:DIS: Init admin pairing table with server storage.
-CHIP:IN: local node id is 0x000000000001b669
-CHIP:DL: MDNS failed to join multicast group on wpan0 for address type IPv4: Inet Error 1016 (0x000003F8): Address not found
-CHIP:ZCL: Using ZAP configuration...
-CHIP:ZCL: deactivate report event
-CHIP:CTL: Getting operational keys
-CHIP:CTL: Generating operational certificate for the controller
-CHIP:CTL: Getting root certificate for the controller from the issuer
-CHIP:CTL: Generating credentials
-CHIP:CTL: Loaded credentials successfully
-CHIP:DL: Platform main loop started.
-Chip Device Controller Shell
-
-chip-device-ctrl >
-```
-
-The prompt `chip-device-ctrl >` indicates that the CHIP core library is loaded
-by Python, you can browse the symbols in the CHIP core library, setting
-breakpoints on functions and many other functions provided by GDB.
-
-You can use `Ctrl-C` to send SIGINT to the controller anytime you want so you
-can set breakpoints.
-
-> (`Ctrl-C` pressed here.)
-
-```
-Thread 1 "python3" received signal SIGINT, Interrupt.
-0x0000fffff7db79ec in __GI___select (nfds=<optimized out>, readfds=0xffffffffe760, writefds=0x0, exceptfds=0x0, timeout=<optimized out>) at ../sysdeps/unix/sysv/linux/select.c:49
-49	../sysdeps/unix/sysv/linux/select.c: No such file or directory.
-(gdb)
-```
-
-For example, you can break on `DeviceCommissioner::PairDevice` by using `break`
-command in GDB (`b` for short)
-
-```
-(gdb) b DeviceCommissioner::PairDevice
-Breakpoint 1 at 0xfffff5b0f6b4 (2 locations)
-(gdb)
-```
-
-Type `continue` (`c` for short) to continue the device controller, you may need
-another hit of `Enter` to see the prompt.
-
-```
-(gdb) c
-Continuing.
-
-chip-device-ctrl >
-```
-
-Let do pairing over IP to see the effect of the breakpoint we just set.
-
-```
-chip-device-ctrl > connect -ip 192.168.50.5 20202021 1
-Device is assigned with nodeid = 1
-
-Thread 1 "python3" hit Breakpoint 1, 0x0000fffff5b0f6b4 in chip::Controller::DeviceCommissioner::PairDevice(unsigned long, chip::RendezvousParameters&)@plt ()
-   from /home/ubuntu/.local/lib/python3.9/site-packages/chip/_ChipDeviceCtrl.so
-(gdb)
-```
-
-The `@plt` symbol means it is a symbol used by dynamic library loader, type `c`
-(for `continue`) and it will break on the real function.
-
-```
-(gdb) c
-Continuing.
-
-Thread 1 "python3" hit Breakpoint 1, chip::Controller::DeviceCommissioner::PairDevice (this=0xd28540, remoteDeviceId=1, params=...) at ../../src/controller/CHIPDeviceController.cpp:827
-827	{
-(gdb)
-```
-
-You can find the `this` pointer, and value of arguments passed to this function,
-then you can use `bt` (for `backtrace`) to see the backtrace of the call stack.
-
-```
-(gdb) bt
-#0  chip::Controller::DeviceCommissioner::PairDevice(unsigned long, chip::RendezvousParameters&) (this=0xd28540, remoteDeviceId=1, params=...)
-    at ../../src/controller/CHIPDeviceController.cpp:827
-#1  0x0000fffff5b3095c in pychip_DeviceController_ConnectIP(chip::Controller::DeviceCommissioner*, char const*, uint32_t, chip::NodeId)
-    (devCtrl=0xd28540, peerAddrStr=0xfffff467ace0 "192.168.50.5", setupPINCode=20202021, nodeid=1) at ../../src/controller/python/ChipDeviceController-ScriptBinding.cpp:234
-#2  0x0000fffff7639148 in  () at /lib/aarch64-linux-gnu/libffi.so.8
-#3  0x0000fffff7638750 in  () at /lib/aarch64-linux-gnu/libffi.so.8
-#4  0x0000fffff7665a44 in  () at /usr/lib/python3.9/lib-dynload/_ctypes.cpython-39-aarch64-linux-gnu.so
-#5  0x0000fffff7664c7c in  () at /usr/lib/python3.9/lib-dynload/_ctypes.cpython-39-aarch64-linux-gnu.so
-#6  0x00000000004a54f0 in _PyObject_MakeTpCall ()
-#7  0x000000000049cb10 in _PyEval_EvalFrameDefault ()
-#8  0x0000000000496d1c in  ()
-#9  0x00000000004b1eb0 in _PyFunction_Vectorcall ()
-#10 0x0000000000498264 in _PyEval_EvalFrameDefault ()
-#11 0x00000000004b1cb8 in _PyFunction_Vectorcall ()
-#12 0x0000000000498418 in _PyEval_EvalFrameDefault ()
-#13 0x0000000000496d1c in  ()
-#14 0x00000000004b1eb0 in _PyFunction_Vectorcall ()
-#15 0x0000000000498418 in _PyEval_EvalFrameDefault ()
-#16 0x00000000004b1cb8 in _PyFunction_Vectorcall ()
-#17 0x00000000004c6bc8 in  ()
-#18 0x0000000000498264 in _PyEval_EvalFrameDefault ()
-#19 0x00000000004b1cb8 in _PyFunction_Vectorcall ()
-#20 0x0000000000498418 in _PyEval_EvalFrameDefault ()
-#21 0x00000000004966f8 in  ()
-#22 0x00000000004b1f18 in _PyFunction_Vectorcall ()
-#23 0x0000000000498418 in _PyEval_EvalFrameDefault ()
-#24 0x00000000004b1cb8 in _PyFunction_Vectorcall ()
-#25 0x0000000000498264 in _PyEval_EvalFrameDefault ()
-#26 0x00000000004966f8 in  ()
-#27 0x0000000000496490 in _PyEval_EvalCodeWithName ()
-#28 0x0000000000595b7c in PyEval_EvalCode ()
-#29 0x00000000005c6a5c in  ()
-#30 0x00000000005c0a70 in  ()
-#31 0x00000000005c69a8 in  ()
-#32 0x00000000005c6148 in PyRun_SimpleFileExFlags ()
-#33 0x00000000005b60bc in Py_RunMain ()
-#34 0x0000000000585a08 in Py_BytesMain ()
-#35 0x0000fffff7d0c9d4 in __libc_start_main (main=
-    0x5858fc <_start+60>, argc=2, argv=0xfffffffff498, init=<optimized out>, fini=<optimized out>, rtld_fini=<optimized out>, stack_end=<optimized out>) at ../csu/libc-start.c:332
-#36 0x00000000005858f8 in _start ()
-(gdb)
-```
-
-The frame #0 and frame #1 are the function frame in the CHIP C++ library, the
-other frames lives in the Python intepreter so you can ignore it.

--- a/src/controller/python/README.md
+++ b/src/controller/python/README.md
@@ -2,101 +2,118 @@
 
 ## Overview
 
-The Python CHIP controller is a tool that allows to commission a Matter device into
-the network and to communicate with it using the Zigbee Cluster Library (ZCL) messages. The tool uses the generic [Chip Device Controller](../) library.
+The Python CHIP controller is a tool that allows to commission a Matter device
+into the network and to communicate with it using the Zigbee Cluster Library
+(ZCL) messages. The tool uses the generic [Chip Device Controller](../) library.
 
-The following instruction describes how to build and test the Python CHIP controller.
+The following instruction describes how to build and test the Python CHIP
+controller.
 
-To learn more about advanced usage of the tool, read the [advanced usage page](ADVANCED_USAGE.md).
+To learn more about advanced usage of the tool, read the
+[advanced usage page](ADVANCED_USAGE.md).
 
 ## Building and installing
 
-Before you can use the Python controller, you must compile it from the source on Linux (amd64 / aarch64) or macOS.
+Before you can use the Python controller, you must compile it from the source on
+Linux (amd64 / aarch64) or macOS.
 
-> To ensure compatibility, build the Python CHIP controller and the Matter device from the same revision of the connectedhomeip repository.
+> To ensure compatibility, build the Python CHIP controller and the Matter
+> device from the same revision of the connectedhomeip repository.
 
 To build and run the Python CHIP controller:
 
-1. Install all necessary packages and prepare the build system. For more details, see the [BUILDING.md](/docs/BUILDING.md) documentation:
+1. Install all necessary packages and prepare the build system. For more
+   details, see the [BUILDING.md](/docs/BUILDING.md) documentation:
 
-   ```
-   sudo apt-get update
-   sudo apt-get upgrade
+    ```
+    sudo apt-get update
+    sudo apt-get upgrade
 
-   sudo apt-get install git gcc g++ python pkg-config libssl-dev libdbus-1-dev libglib2.0-dev libavahi-client-dev ninja-build python3-venv python3-dev python3-pip unzip libgirepository1.0-dev libcairo2-dev bluez
-   ```
+    sudo apt-get install git gcc g++ python pkg-config libssl-dev libdbus-1-dev libglib2.0-dev libavahi-client-dev ninja-build python3-venv python3-dev python3-pip unzip libgirepository1.0-dev libcairo2-dev bluez
+    ```
 
-   If the Python CHIP controller is built on a Raspberry Pi, install additional packages and reboot the device:
+    If the Python CHIP controller is built on a Raspberry Pi, install additional
+    packages and reboot the device:
 
-   ```
-   sudo apt-get install pi-bluetooth
-   sudo reboot
-   ```
+    ```
+    sudo apt-get install pi-bluetooth
+    sudo reboot
+    ```
 
 2. Clone the Project CHIP repository:
 
-   ```
-   git clone https://github.com/project-chip/connectedhomeip.git
-   ```
+    ```
+    git clone https://github.com/project-chip/connectedhomeip.git
+    ```
 
 3. Enter the `connectedhomeip` directory:
 
-   ```
-   cd connectedhomeip
-   ```
+    ```
+    cd connectedhomeip
+    ```
 
 4. Initialize the git submodules:
 
-   ```
-   git submodule update --init
-   ```
+    ```
+    git submodule update --init
+    ```
 
 5. Build and install the Python CHIP controller:
 
-   ```
-   scripts/build_python.sh -m platform
-   ```
+    ```
+    scripts/build_python.sh -m platform
+    ```
 
-   > Note: To get more details about available build configurations, run the following command:
-   > ```scripts/build_python.sh --help```
+    > Note: To get more details about available build configurations, run the
+    > following command: `scripts/build_python.sh --help`
 
 ## Running the tool
 
 1. Activate the Python virtual environment:
 
-   ```
-   source out/python_env/bin/activate
-   ```
+    ```
+    source out/python_env/bin/activate
+    ```
 
-2. Run the Python CHIP controller with root privileges, which is required to obtain access to the Bluetooth interface:
+2. Run the Python CHIP controller with root privileges, which is required to
+   obtain access to the Bluetooth interface:
 
-   ```
-   sudo out/python_env/bin/chip-device-ctrl
-   ```
+    ```
+    sudo out/python_env/bin/chip-device-ctrl
+    ```
 
-   You can also select the Bluetooth LE interface using command line argument:
+    You can also select the Bluetooth LE interface using command line argument:
 
-   ```
-   sudo out/python_env/bin/chip-device-ctrl --bluetooth-adapter=hci2
-   ```
+    ```
+    sudo out/python_env/bin/chip-device-ctrl --bluetooth-adapter=hci2
+    ```
 
 ## Working with Python CHIP Controller
 
-This section describes how to use Python CHIP controller to test the Matter accessory. Below steps depends on the application clusters that you implemented on the device side and may be different for your accessory.
+This section describes how to use Python CHIP controller to test the Matter
+accessory. Below steps depend on the application clusters that you implemented
+on the device side and may be different for your accessory.
 
 ### Step 1: Prepare the Matter accessory.
 
-This tutorial is using the [Matter Light Bulb](/examples/lighting-app) example with the Bluetooth LE commissioning. However, you can adapt this procedure to other available [Matter examples](/examples).
+This tutorial is using the [Matter Light Bulb](/examples/lighting-app) example
+with the Bluetooth LE commissioning. However, you can adapt this procedure to
+other available [Matter examples](/examples).
 
-Build and program the device with the Matter accessory firmware by following the example's documentation.
+Build and program the device with the Matter accessory firmware by following the
+example's documentation.
 
 ### Step 2: Enable Bluetooth LE advertising on Matter accessory device.
 
-Some examples are configured to advertise automatically on boot. Other examples require physical trigger, for example pushing a button. Follow the documentation of the Matter accessory example to learn how Bluetooth LE advertising is enabled for the given example.
+Some examples are configured to advertise automatically on boot. Other examples
+require physical trigger, for example pushing a button. Follow the documentation
+of the Matter accessory example to learn how Bluetooth LE advertising is enabled
+for the given example.
 
 ### Step 3: Discover Matter accessory device over Bluetooth LE
 
-An uncommissioned accessory device advertises over Bluetooth LE. Run the following command to scan all advertised Matter devices:
+An uncommissioned accessory device advertises over Bluetooth LE. Run the
+following command to scan all advertised Matter devices:
 
 ```
 chip-device-ctrl > ble-scan
@@ -104,7 +121,10 @@ chip-device-ctrl > ble-scan
 
 ### Step 4: Connect to Matter accessory device over Bluetooth LE
 
-The controller uses a 12-bit value called **discriminator** to discern between multiple commissionable device advertisements. Moreover, a 27-bit **PIN code** is used by the controller to authenticate in the device. You can find those values in the logging terminal of the device (for example, UART). For example:
+The controller uses a 12-bit value called **discriminator** to discern between
+multiple commissionable device advertisements. Moreover, a 27-bit **PIN code**
+is used by the controller to authenticate in the device. You can find those
+values in the logging terminal of the device (for example, UART). For example:
 
 ```
 I: 254 [DL]Device Configuration:
@@ -118,91 +138,112 @@ I: 278 [DL] Manufacturing Date: (not set)
 I: 281 [DL] Device Type: 65535 (0xFFFF)
 ```
 
-Run the following command to establish the secure connection over Bluetooth LE, with the following assumptions for the Matter accessory device:
- - The discriminator of the device is *3840*
- - The setup pin code of the device is *20202021*
- - The temporary Node ID is *1234*
+Run the following command to establish the secure connection over Bluetooth LE,
+with the following assumptions for the Matter accessory device:
+
+-   The discriminator of the device is _3840_
+-   The setup pin code of the device is _20202021_
+-   The temporary Node ID is _1234_
 
 ```
 chip-device-ctrl > connect -ble 3840 20202021 1234
 ```
 
-You can skip the last parameter, that is the Node ID. If you skip it, the controller will assign it randomly. However, note the Node ID down, because it is required later in the configuration process.
+You can skip the last parameter, that is the Node ID. If you skip it, the
+controller will assign it randomly. However, note the Node ID down, because it
+is required later in the configuration process.
 
-At the end of the secure connection establishment, the Python controller prints the following log:
+At the end of the secure connection establishment, the Python controller prints
+the following log:
 
 ```
 Secure Session to Device Established
 ```
 
-This means that the PASE (Password-Authenticated Session Establishment) session using SPAKE2+ protocol is completed.
+This means that the PASE (Password-Authenticated Session Establishment) session
+using SPAKE2+ protocol is completed.
 
 ### Step 5: Commission Matter accessory to the underlying network
 
-The main goal of the network commissioning step is to configure the device with a network interface, such as Thread or Wi-Fi. This process provides the device with network credentials.
+The main goal of the network commissioning step is to configure the device with
+a network interface, such as Thread or Wi-Fi. This process provides the device
+with network credentials.
 
 #### Commissioning a Thread device
 
-1. Fetch and store the current Active Operational Dataset and Extended PAN ID from the Thread Border Router.
-   Depending if Thread Border Router is running on Docker or natively on Raspberry Pi, execute the following commands:
+1. Fetch and store the current Active Operational Dataset and Extended PAN ID
+   from the Thread Border Router. Depending if Thread Border Router is running
+   on Docker or natively on Raspberry Pi, execute the following commands:
 
-   - For Docker:
+    - For Docker:
 
-      ```
-      sudo docker exec -it otbr sh -c "sudo ot-ctl dataset active -x"
-      0e080000000000010000000300001335060004001fffe002084fe76e9a8b5edaf50708fde46f999f0698e20510d47f5027a414ffeebaefa92285cc84fa030f4f70656e5468726561642d653439630102e49c0410b92f8c7fbb4f9f3e08492ee3915fbd2f0c0402a0fff8
-      Done
+        ```
+        sudo docker exec -it otbr sh -c "sudo ot-ctl dataset active -x"
+        0e080000000000010000000300001335060004001fffe002084fe76e9a8b5edaf50708fde46f999f0698e20510d47f5027a414ffeebaefa92285cc84fa030f4f70656e5468726561642d653439630102e49c0410b92f8c7fbb4f9f3e08492ee3915fbd2f0c0402a0fff8
+        Done
 
-      sudo docker exec -it otbr sh -c "sudo ot-ctl dataset extpanid”
-      4fe76e9a8b5edaf5
-      Done
-      ```
+        sudo docker exec -it otbr sh -c "sudo ot-ctl dataset extpanid”
+        4fe76e9a8b5edaf5
+        Done
+        ```
 
-   - For native installation:
+    - For native installation:
 
-      ```
-      sudo ot-ctl dataset active -x
-      0e080000000000010000000300001335060004001fffe002084fe76e9a8b5edaf50708fde46f999f0698e20510d47f5027a414ffeebaefa92285cc84fa030f4f70656e5468726561642d653439630102e49c0410b92f8c7fbb4f9f3e08492ee3915fbd2f0c0402a0fff8
-      Done
+        ```
+        sudo ot-ctl dataset active -x
+        0e080000000000010000000300001335060004001fffe002084fe76e9a8b5edaf50708fde46f999f0698e20510d47f5027a414ffeebaefa92285cc84fa030f4f70656e5468726561642d653439630102e49c0410b92f8c7fbb4f9f3e08492ee3915fbd2f0c0402a0fff8
+        Done
 
-      sudo ot-ctl dataset extpanid
-      4fe76e9a8b5edaf5
-      Done
-      ```
+        sudo ot-ctl dataset extpanid
+        4fe76e9a8b5edaf5
+        Done
+        ```
 
-   Matter specifiction does not define how the Thread or Wi-Fi credentials are obtained by Controller. For example, for Thread, instead of fetching datasets directly from the Thread Border Router, you might also use a different out-of-band method.
-2. Inject the previously obtained Active Operational Dataset as hex-encoded value using ZCL Network Commissioning cluster:
+    Matter specifiction does not define how the Thread or Wi-Fi credentials are
+    obtained by Controller. For example, for Thread, instead of fetching
+    datasets directly from the Thread Border Router, you might also use a
+    different out-of-band method.
 
-   > Each ZCL command has a following format:
-      `zcl <Cluster> <Command> <Node Id> <Endpoint Id> <Group Id> [arguments]`
+2. Inject the previously obtained Active Operational Dataset as hex-encoded
+   value using ZCL Network Commissioning cluster:
 
-   ```
-   chip-device-ctrl > zcl NetworkCommissioning AddThreadNetwork 1234 0 0 operationalDataset=hex:0e080000000000010000000300001335060004001fffe002084fe76e9a8b5edaf50708fde46f999f0698e20510d47f5027a414ffeebaefa92285cc84fa030f4f70656e5468726561642d653439630102e49c0410b92f8c7fbb4f9f3e08492ee3915fbd2f0c0402a0fff8 breadcrumb=0 timeoutMs=3000
-   ```
+    > Each ZCL command has a following format:
+    > `zcl <Cluster> <Command> <Node Id> <Endpoint Id> <Group Id> [arguments]`
 
-3. Enable Thread interface on the device by executing the following command with `networkID` equal to Extended PAN Id of the Thread network:
+    ```
+    chip-device-ctrl > zcl NetworkCommissioning AddThreadNetwork 1234 0 0 operationalDataset=hex:0e080000000000010000000300001335060004001fffe002084fe76e9a8b5edaf50708fde46f999f0698e20510d47f5027a414ffeebaefa92285cc84fa030f4f70656e5468726561642d653439630102e49c0410b92f8c7fbb4f9f3e08492ee3915fbd2f0c0402a0fff8 breadcrumb=0 timeoutMs=3000
+    ```
 
-   ```
-   chip-device-ctrl > zcl NetworkCommissioning EnableNetwork 1234 0 0 networkID=hex:4fe76e9a8b5edaf5 breadcrumb=0 timeoutMs=3000
-   ```
+3. Enable Thread interface on the device by executing the following command with
+   `networkID` equal to Extended PAN Id of the Thread network:
+
+    ```
+    chip-device-ctrl > zcl NetworkCommissioning EnableNetwork 1234 0 0 networkID=hex:4fe76e9a8b5edaf5 breadcrumb=0 timeoutMs=3000
+    ```
 
 #### Commissioning a Wi-Fi device
 
-1. Assuming your Wi-Fi SSID is `TESTSSID`, and your Wi-Fi password is `P455W4RD`, inject the credentials to the device by excuting the following command:
+1. Assuming your Wi-Fi SSID is _TESTSSID_, and your Wi-Fi password is
+   _P455W4RD_, inject the credentials to the device by excuting the following
+   command:
 
-   ```
-   chip-device-ctrl > zcl NetworkCommissioning AddWiFiNetwork 1234 0 0 ssid=str:TESTSSID credentials=str:P455W4RD breadcrumb=0 timeoutMs=1000
-   ```
+    ```
+    chip-device-ctrl > zcl NetworkCommissioning AddWiFiNetwork 1234 0 0 ssid=str:TESTSSID credentials=str:P455W4RD breadcrumb=0 timeoutMs=1000
+    ```
 
 2. Enable the Wi-Fi interface on the device by executing the following command:
 
-   ```
-   chip-device-ctrl > zcl NetworkCommissioning EnableNetwork 1234 0 0 networkID=str:TESTSSID breadcrumb=0 timeoutMs=1000
-   ```
+    ```
+    chip-device-ctrl > zcl NetworkCommissioning EnableNetwork 1234 0 0 networkID=str:TESTSSID breadcrumb=0 timeoutMs=1000
+    ```
 
 ### Step 6: Close Bluetooth LE connection.
 
-After the Matter accessory device was provisioned with Thread or Wi-Fi credentials (or both), the commissioning process is finished. The Python CHIP controller is now using only the IPv6 traffic to reach the device, so you can close the Bluetooth LE connection. To close the connection, run the following command:
+After the Matter accessory device was provisioned with Thread or Wi-Fi
+credentials (or both), the commissioning process is finished. The Python CHIP
+controller is now using only the IPv6 traffic to reach the device, so you can
+close the Bluetooth LE connection. To close the connection, run the following
+command:
 
 ```
 chip-device-ctrl > close-ble
@@ -210,27 +251,36 @@ chip-device-ctrl > close-ble
 
 ### Step 7: Discover IPv6 address of the Matter accessory.
 
-The Matter controller must discover the IPv6 address of the node that it previously commissioned. Depending on the network type:
-- For Thread, the Matter accessory uses SRP (Service Registration Protocol) to register its presence on the Thread Border Router’s SRP Server.
-- For Wi-Fi or Ethernet devices, the Matter accessory uses the mDNS (Multicast Domain Name System) protocol.
+The Matter controller must discover the IPv6 address of the node that it
+previously commissioned. Depending on the network type:
 
-Assuming your Fabric ID is *5544332211* and Node ID is *1234* (use the Node ID you noted down when you established the secure connection over Bluetooth LE)), run the following command:
+-   For Thread, the Matter accessory uses SRP (Service Registration Protocol) to
+    register its presence on the Thread Border Router’s SRP Server.
+-   For Wi-Fi or Ethernet devices, the Matter accessory uses the mDNS (Multicast
+    Domain Name System) protocol.
+
+Assuming your Fabric ID is _5544332211_ and Node ID is _1234_ (use the Node ID
+you noted down when you established the secure connection over Bluetooth LE)),
+run the following command:
 
 ```
 chip-device-ctrl > resolve 5544332211 1234
 ```
 
-A notification in the log indicates that the node address has been updated. The IPv6 address of the device is cached in the controller for later usage.
+A notification in the log indicates that the node address has been updated. The
+IPv6 address of the device is cached in the controller for later usage.
 
 ### Step 8: Control application ZCL clusters.
 
-For the light bulb example, execute the following command to toggle the LED state:
+For the light bulb example, execute the following command to toggle the LED
+state:
 
 ```
 chip-device-ctrl > zcl OnOff Toggle 1234 1 0
 ```
 
-To change the brightness of the LED, use the following command, with the level value somewhere between 0 and 255.
+To change the brightness of the LED, use the following command, with the level
+value somewhere between 0 and 255.
 
 ```
 chip-device-ctrl > zcl LevelControl MoveToLevel 1234 1 0 level=50
@@ -238,7 +288,10 @@ chip-device-ctrl > zcl LevelControl MoveToLevel 1234 1 0 level=50
 
 ### Step 9: Read basic information out of the accessory.
 
-Every Matter accessory device supports a Basic Cluster, which maintains collection of attributes that a controller can obtain from a device, such as the vendor name, the product name, or software version. Use `zclread` command to read those values from the device:
+Every Matter accessory device supports a Basic Cluster, which maintains
+collection of attributes that a controller can obtain from a device, such as the
+vendor name, the product name, or software version. Use `zclread` command to
+read those values from the device:
 
 ```
 chip-device-ctrl > zclread Basic VendorName 1234 1 0
@@ -246,7 +299,8 @@ chip-device-ctrl > zclread Basic ProductName 1234 1 0
 chip-device-ctrl > zclread Basic SoftwareVersion 1234 1 0
 ```
 
-> Use the `zcl ? Basic` command to list all available commands for Basic Cluster.
+> Use the `zcl ? Basic` command to list all available commands for Basic
+> Cluster.
 
 ## List of commands
 
@@ -269,8 +323,9 @@ chip-device-ctrl > ble-debug-log 1
 
 ### `ble-scan [-t <timeout>] [identifier]`
 
-Start a scan action to search for valid CHIP devices over Bluetooth LE (for at most *timeout* seconds).
-Stop when the device is matching the identifier or the counter times out.
+Start a scan action to search for valid CHIP devices over Bluetooth LE (for at
+most _timeout_ seconds). Stop when the device is matching the identifier or the
+counter times out.
 
 ```
 chip-device-ctrl > ble-scan
@@ -285,7 +340,7 @@ chip-device-ctrl > ble-scan
 2021-05-29 22:28:07,209 ChipBLEMgr   INFO     Product Id      = 20044
 2021-05-29 22:28:07,210 ChipBLEMgr   INFO     Adv UUID        = 0000fff6-0000-1000-8000-00805f9b34fb
 2021-05-29 22:28:07,210 ChipBLEMgr   INFO     Adv Data        = 00000f5a234c4e
-2021-05-29 22:28:07,210 ChipBLEMgr   INFO    
+2021-05-29 22:28:07,210 ChipBLEMgr   INFO
 2021-05-29 22:28:16,246 ChipBLEMgr   INFO     scanning stopped
 ```
 
@@ -321,7 +376,8 @@ chip-device-ctrl > discover -all
 
 ### `resolve <fabric_id> <node_id>`
 
-Resolve DNS-SD name corresponding with the given fabric and Node IDs and update address of the node in the device controller:
+Resolve DNS-SD name corresponding with the given fabric and Node IDs and update
+address of the node in the device controller:
 
 ```
 chip-device-ctrl > resolve 5544332211 1234
@@ -426,7 +482,7 @@ WindowCovering
 
 ### `zcl ? <Cluster>`
 
-List available commands in cluster. For example, for *Basic* cluster:
+List available commands in cluster. For example, for _Basic_ cluster:
 
 ```
 chip-device-ctrl > zcl ? Basic

--- a/src/controller/python/README.md
+++ b/src/controller/python/README.md
@@ -2,14 +2,14 @@
 
 ## Overview
 
-The Python CHIP controller allows to commission the Matter device into
-the network as well as communicate with it using the Zigbee Cluster Library (ZCL) messages. The tool utilizes the generic [Chip Device Controller](../) library.
+The Python CHIP controller is a tool that allows to commission a Matter device into
+the network and to communicate with it using the Zigbee Cluster Library (ZCL) messages. The tool uses the generic [Chip Device Controller](../) library.
 
-Below instruction presents how to build and test Python CHIP controller. The sample test flow may vary depending on the application clusters implemented on the device side.
+The following instruction describes how to build and test the Python CHIP controller.
 
-To learn more about advanced usage of the tool, check [extended documentation](ADVANCED_USAGE.md).
+To learn more about advanced usage of the tool, read the [advanced usage page](ADVANCED_USAGE.md).
 
-## Checkout / Build / Install
+## Building and installing
 
 Before you can use the Python controller, you must compile it from the source on Linux (amd64 / aarch64) or macOS.
 
@@ -17,7 +17,7 @@ Before you can use the Python controller, you must compile it from the source on
 
 To build and run the Python CHIP controller:
 
-1. Install all necessary packages and prepare the build system. For more details, see the [BUILDING.md](/docs/BUILDING.md) documentation.
+1. Install all necessary packages and prepare the build system. For more details, see the [BUILDING.md](/docs/BUILDING.md) documentation:
 
    ```
    sudo apt-get update
@@ -33,25 +33,25 @@ To build and run the Python CHIP controller:
    sudo reboot
    ```
 
-2. Clone the Project CHIP repository.
+2. Clone the Project CHIP repository:
 
    ```
    git clone https://github.com/project-chip/connectedhomeip.git
    ```
 
-3. Enter the `connectedhomeip` directory.
+3. Enter the `connectedhomeip` directory:
 
    ```
    cd connectedhomeip
    ```
 
-4. Initialize the git submodules.
+4. Initialize the git submodules:
 
    ```
    git submodule update --init
    ```
 
-5. Build and install the Python CHIP controller.
+5. Build and install the Python CHIP controller:
 
    ```
    scripts/build_python.sh -m platform
@@ -60,15 +60,15 @@ To build and run the Python CHIP controller:
    > Note: To get more details about available build configurations, run the following command:
    > ```scripts/build_python.sh --help```
 
-6. Activate the Python virtual environment.
+## Running the tool
+
+1. Activate the Python virtual environment:
 
    ```
    source out/python_env/bin/activate
    ```
 
-7. Run the Python CHIP controller.
-
-   > Running as root is necessary to obtain access to the Bluetooth interface.
+2. Run the Python CHIP controller with root privileges, which is required to obtain access to the Bluetooth interface:
 
    ```
    sudo out/python_env/bin/chip-device-ctrl
@@ -82,17 +82,19 @@ To build and run the Python CHIP controller:
 
 ## Working with Python CHIP Controller
 
-### 1. Prepare the Matter accessory.
+This section describes how to use Python CHIP controller to test the Matter accessory. Below steps depends on the application clusters that you implemented on the device side and may be different for your accessory.
 
-In this tutorial, the [Matter: Light Bulb](/examples/lighting-app) example with Bluetooth LE commissioning will be used, but similar steps can be executed with the rest of the examples. Check [Matter examples](/examples) for the list of available samples.
+### Step 1: Prepare the Matter accessory.
+
+This tutorial is using the [Matter Light Bulb](/examples/lighting-app) example with the Bluetooth LE commissioning. However, you can adapt this procedure to other available [Matter examples](/examples).
 
 Build and program the device with the Matter accessory firmware by following the example's documentation.
 
-### 2. Enable Bluetooth LE advertising on Matter accessory device.
+### Step 2: Enable Bluetooth LE advertising on Matter accessory device.
 
-Some examples are configured to advertise automatically on boot, others require physical trigger like pushing the button. Follow the Matter accessory example's documentation to learn how Bluetooth LE advertising is enabled.
+Some examples are configured to advertise automatically on boot. Other examples require physical trigger, for example pushing a button. Follow the documentation of the Matter accessory example to learn how Bluetooth LE advertising is enabled for the given example.
 
-### 3. Discover Matter accessory device over Bluetooth LE
+### Step 3: Discover Matter accessory device over Bluetooth LE
 
 An uncommissioned accessory device advertises over Bluetooth LE. Run the following command to scan all advertised Matter devices:
 
@@ -100,9 +102,9 @@ An uncommissioned accessory device advertises over Bluetooth LE. Run the followi
 chip-device-ctrl > ble-scan
 ```
 
-### 4. Connect to Matter accessory device over Bluetooth LE
+### Step 4: Connect to Matter accessory device over Bluetooth LE
 
-The controller uses a 12-bit value called **discriminator** to discern between multiple commissionable device advertisements. Moreover, a 27-bit **PIN code** is used by the controller to authenticate in the device. You can find those values in the logging terminal of the device (e.g. UART), as listed below.
+The controller uses a 12-bit value called **discriminator** to discern between multiple commissionable device advertisements. Moreover, a 27-bit **PIN code** is used by the controller to authenticate in the device. You can find those values in the logging terminal of the device (for example, UART). For example:
 
 ```
 I: 254 [DL]Device Configuration:
@@ -116,18 +118,18 @@ I: 278 [DL] Manufacturing Date: (not set)
 I: 281 [DL] Device Type: 65535 (0xFFFF)
 ```
 
-Run the following command to establish secure connection over Bluetooth LE, with the following assumptions for the Matter accessory device:
- - The discriminator of the device is 3840
- - The setup pin code of the device is 20202021
- - The temporary Node ID is 1234
+Run the following command to establish the secure connection over Bluetooth LE, with the following assumptions for the Matter accessory device:
+ - The discriminator of the device is *3840*
+ - The setup pin code of the device is *20202021*
+ - The temporary Node ID is *1234*
 
 ```
 chip-device-ctrl > connect -ble 3840 20202021 1234
 ```
 
-You may skip providing the last parameter which is a Node ID. In such case, the controller will randomly assign it. However, note the Node ID down, because it is required later in the configuration process.
+You can skip the last parameter, that is the Node ID. If you skip it, the controller will assign it randomly. However, note the Node ID down, because it is required later in the configuration process.
 
-At the end of the secure connection establishment, the Python controller will indicate this by printing the following log:
+At the end of the secure connection establishment, the Python controller prints the following log:
 
 ```
 Secure Session to Device Established
@@ -135,42 +137,41 @@ Secure Session to Device Established
 
 This means that the PASE (Password-Authenticated Session Establishment) session using SPAKE2+ protocol is completed.
 
-### 5. Commission Matter accessory to the underlying network
+### Step 5: Commission Matter accessory to the underlying network
 
-One of the commissioning steps is Network Commissioning. The main goal of this step is to configure a network interface, such as Thread or Wifi, on the device and to provide it with network credentials.
+The main goal of the network commissioning step is to configure the device with a network interface, such as Thread or Wi-Fi. This process provides the device with network credentials.
 
-#### Commissioning of Thread device
+#### Commissioning a Thread device
 
 1. Fetch and store the current Active Operational Dataset and Extended PAN ID from the Thread Border Router.
-
    Depending if Thread Border Router is running on Docker or natively on Raspberry Pi, execute the following commands:
 
-   For Docker:
-   ```
-   sudo docker exec -it otbr sh -c "sudo ot-ctl dataset active -x"
-   0e080000000000010000000300001335060004001fffe002084fe76e9a8b5edaf50708fde46f999f0698e20510d47f5027a414ffeebaefa92285cc84fa030f4f70656e5468726561642d653439630102e49c0410b92f8c7fbb4f9f3e08492ee3915fbd2f0c0402a0fff8
-   Done
+   - For Docker:
 
-   sudo docker exec -it otbr sh -c "sudo ot-ctl dataset extpanid”
-   4fe76e9a8b5edaf5
-   Done
-   ```
+      ```
+      sudo docker exec -it otbr sh -c "sudo ot-ctl dataset active -x"
+      0e080000000000010000000300001335060004001fffe002084fe76e9a8b5edaf50708fde46f999f0698e20510d47f5027a414ffeebaefa92285cc84fa030f4f70656e5468726561642d653439630102e49c0410b92f8c7fbb4f9f3e08492ee3915fbd2f0c0402a0fff8
+      Done
 
-   For native installation:
+      sudo docker exec -it otbr sh -c "sudo ot-ctl dataset extpanid”
+      4fe76e9a8b5edaf5
+      Done
+      ```
 
-   ```
-   sudo ot-ctl dataset active -x
-   0e080000000000010000000300001335060004001fffe002084fe76e9a8b5edaf50708fde46f999f0698e20510d47f5027a414ffeebaefa92285cc84fa030f4f70656e5468726561642d653439630102e49c0410b92f8c7fbb4f9f3e08492ee3915fbd2f0c0402a0fff8
-   Done
+   - For native installation:
 
-   sudo ot-ctl dataset extpanid
-   4fe76e9a8b5edaf5
-   Done
-   ```
+      ```
+      sudo ot-ctl dataset active -x
+      0e080000000000010000000300001335060004001fffe002084fe76e9a8b5edaf50708fde46f999f0698e20510d47f5027a414ffeebaefa92285cc84fa030f4f70656e5468726561642d653439630102e49c0410b92f8c7fbb4f9f3e08492ee3915fbd2f0c0402a0fff8
+      Done
 
-   Matter specifiction does not define how the Thread or Wi-Fi credentials are obtained by Controller. For example, for Thread, instead of fetching datasets directly from the Thread Border Router, you may also use different out-of-band method.
+      sudo ot-ctl dataset extpanid
+      4fe76e9a8b5edaf5
+      Done
+      ```
 
-2. Inject the previously obtained Active Operational Dataset as hex-encoded value using ZCL Network Commissioning cluster.
+   Matter specifiction does not define how the Thread or Wi-Fi credentials are obtained by Controller. For example, for Thread, instead of fetching datasets directly from the Thread Border Router, you might also use a different out-of-band method.
+2. Inject the previously obtained Active Operational Dataset as hex-encoded value using ZCL Network Commissioning cluster:
 
    > Each ZCL command has a following format:
       `zcl <Cluster> <Command> <Node Id> <Endpoint Id> <Group Id> [arguments]`
@@ -179,65 +180,65 @@ One of the commissioning steps is Network Commissioning. The main goal of this s
    chip-device-ctrl > zcl NetworkCommissioning AddThreadNetwork 1234 0 0 operationalDataset=hex:0e080000000000010000000300001335060004001fffe002084fe76e9a8b5edaf50708fde46f999f0698e20510d47f5027a414ffeebaefa92285cc84fa030f4f70656e5468726561642d653439630102e49c0410b92f8c7fbb4f9f3e08492ee3915fbd2f0c0402a0fff8 breadcrumb=0 timeoutMs=3000
    ```
 
-3. Enable Thread interface in the device by executing the following command with `networkID` equal to Extended PAN Id of the Thread network.
+3. Enable Thread interface on the device by executing the following command with `networkID` equal to Extended PAN Id of the Thread network:
 
    ```
    chip-device-ctrl > zcl NetworkCommissioning EnableNetwork 1234 0 0 networkID=hex:4fe76e9a8b5edaf5 breadcrumb=0 timeoutMs=3000
    ```
 
-#### Commissioning of Wi-Fi device
+#### Commissioning a Wi-Fi device
 
-1. Assuming your Wi-Fi SSID is *TESTSSID*, and your Wi-Fi password is *P455W4RD*, inject the credentials to the device by excuting the following command.
+1. Assuming your Wi-Fi SSID is `TESTSSID`, and your Wi-Fi password is `P455W4RD`, inject the credentials to the device by excuting the following command:
 
    ```
    chip-device-ctrl > zcl NetworkCommissioning AddWiFiNetwork 1234 0 0 ssid=str:TESTSSID credentials=str:P455W4RD breadcrumb=0 timeoutMs=1000
    ```
 
-2. Enable Wi-Fi interface in the device by executing the following command:
+2. Enable the Wi-Fi interface on the device by executing the following command:
 
    ```
    chip-device-ctrl > zcl NetworkCommissioning EnableNetwork 1234 0 0 networkID=str:TESTSSID breadcrumb=0 timeoutMs=1000
    ```
 
-### 6. Close Bluetooth LE connection.
+### Step 6: Close Bluetooth LE connection.
 
-After Matter accessory was provisioned with Thread and/or Wi-Fi credentials, the commissioning process is finished. Python CHIP controller will now use only IPv6 traffic to reach the device, so Bluetooth LE connection can be closed.
+After the Matter accessory device was provisioned with Thread or Wi-Fi credentials (or both), the commissioning process is finished. The Python CHIP controller is now using only the IPv6 traffic to reach the device, so you can close the Bluetooth LE connection. To close the connection, run the following command:
 
 ```
 chip-device-ctrl > close-ble
 ```
 
-### 7. Discover IPv6 address of the Matter accessory.
+### Step 7: Discover IPv6 address of the Matter accessory.
 
-The Matter controller needs to discover IPv6 address of the node that it previously commissioned. For Thread, the Matter accessory uses SRP (Service Registration Protocol) to register its presence on the Thread Border Router’s SRP Server, for Wi-Fi or Ethernet devices, the mDNS (Multicast Domain Name System) protocol is used instead.
+The Matter controller must discover the IPv6 address of the node that it previously commissioned. Depending on the network type:
+- For Thread, the Matter accessory uses SRP (Service Registration Protocol) to register its presence on the Thread Border Router’s SRP Server.
+- For Wi-Fi or Ethernet devices, the Matter accessory uses the mDNS (Multicast Domain Name System) protocol.
 
-Run the following command, assuming that:
- - The Fabric ID of the device is 5544332211
- - The Node ID is 1234
+Assuming your Fabric ID is *5544332211* and Node ID is *1234* (use the Node ID you noted down when you established the secure connection over Bluetooth LE)), run the following command:
 
 ```
 chip-device-ctrl > resolve 5544332211 1234
 ```
 
-After successful resolution, you should see the log indicating that node address has been updated. The IPv6 address of the device will be cached in the controller for later usage.
+A notification in the log indicates that the node address has been updated. The IPv6 address of the device is cached in the controller for later usage.
 
-### 8. Control application ZCL clusters.
+### Step 8: Control application ZCL clusters.
 
-For Light Bulb example, execute the following command to toggle the LED state:
+For the light bulb example, execute the following command to toggle the LED state:
 
 ```
 chip-device-ctrl > zcl OnOff Toggle 1234 1 0
 ```
 
-To change the brightness of the LED, use the following command, with level changed to the value between 0 and 255.
+To change the brightness of the LED, use the following command, with the level value somewhere between 0 and 255.
 
 ```
 chip-device-ctrl > zcl LevelControl MoveToLevel 1234 1 0 level=50
 ```
 
-### 9. Read basic information out of the accessory.
+### Step 9: Read basic information out of the accessory.
 
-Every Matter accessory device supports Basic Cluster which maintains collection of attributes that a controller may obtain from a device, such as the vendor name, the product name, or software version. Use `zclread` command to read those values out of the device:
+Every Matter accessory device supports a Basic Cluster, which maintains collection of attributes that a controller can obtain from a device, such as the vendor name, the product name, or software version. Use `zclread` command to read those values from the device:
 
 ```
 chip-device-ctrl > zclread Basic VendorName 1234 1 0
@@ -251,7 +252,7 @@ chip-device-ctrl > zclread Basic SoftwareVersion 1234 1 0
 
 ### `ble-adapter-print`
 
-Print the available Bluetooth adapters on device. Takes no arguments.
+Print the available Bluetooth adapters on device. Takes no arguments:
 
 ```
 chip-device-ctrl > ble-adapter-print
@@ -260,7 +261,7 @@ chip-device-ctrl > ble-adapter-print
 
 ### `ble-debug-log`
 
-Enable Bluetooth LE debug logs.
+Enable the Bluetooth LE debug logs.
 
 ```
 chip-device-ctrl > ble-debug-log 1
@@ -268,8 +269,8 @@ chip-device-ctrl > ble-debug-log 1
 
 ### `ble-scan [-t <timeout>] [identifier]`
 
-Start a ble-scan action for searching valid CHIP devices over Bluetooth LE [for at most
-*timeout* seconds], stop when device matching the identifier or timeout.
+Start a scan action to search for valid CHIP devices over Bluetooth LE (for at most *timeout* seconds).
+Stop when the device is matching the identifier or the counter times out.
 
 ```
 chip-device-ctrl > ble-scan
@@ -293,26 +294,26 @@ chip-device-ctrl > ble-scan
 Do key exchange and establish a secure session between controller and device
 using IP transport.
 
-The node id will be used by controller to distinguish multiple devices. This
+The Node ID will be used by controller to distinguish multiple devices. This
 does not match the spec and will be removed later. The nodeid will not be
 persisted by controller / device.
 
-If no nodeid given, a random node id will be used.
+If no nodeid given, a random Node ID will be used.
 
 ### `connect -ble <discriminator> <SetUpPinCode> [<nodeid>]`
 
 Do key exchange and establish a secure session between controller and device
 using Bluetooth LE transport.
 
-The node id will be used by controller to distinguish multiple devices. This
+The Node ID will be used by controller to distinguish multiple devices. This
 does not match the spec and will be removed later. The nodeid will not be
 persisted by controller / device.
 
-If no nodeid given, a random node id will be used.
+If no nodeid given, a random Node ID will be used.
 
 ### `discover`
 
-Discover available Matter accessory devices.
+Discover available Matter accessory devices:
 
 ```
 chip-device-ctrl > discover -all
@@ -320,7 +321,7 @@ chip-device-ctrl > discover -all
 
 ### `resolve <fabric_id> <node_id>`
 
-Resolve DNS-SD name corresponding with the given fabric and node IDs and update address of the node in the device controller.
+Resolve DNS-SD name corresponding with the given fabric and Node IDs and update address of the node in the device controller:
 
 ```
 chip-device-ctrl > resolve 5544332211 1234
@@ -328,7 +329,7 @@ chip-device-ctrl > resolve 5544332211 1234
 
 ### `setup-payload parse-manual <manual-pairing-code>`
 
-Print the commissioning information encoded in the Manual Pairing Code.
+Print the commissioning information encoded in the Manual Pairing Code:
 
 ```
 chip-device-ctrl > setup-payload parse-manual 35767807533
@@ -343,7 +344,7 @@ SetUpPINCode: 20202021
 
 ### `setup-payload parse-qr <qr-code>`
 
-Print the commissioning information encoded in the QR Code payload.
+Print the commissioning information encoded in the QR Code payload:
 
 ```
 chip-device-ctrl > setup-payload parse-qr "VP:vendorpayload%CH:H34.GHY00 0C9SS0"
@@ -377,7 +378,7 @@ example, `networkId=hex:0123456789abcdef` (for
 
 ### `zcl ?`
 
-List available clusters.
+List available clusters:
 
 ```
 chip-device-ctrl > zcl ?
@@ -425,7 +426,7 @@ WindowCovering
 
 ### `zcl ? <Cluster>`
 
-List available commands in cluster. For example, for *LevlControl* cluster:
+List available commands in cluster. For example, for *Basic* cluster:
 
 ```
 chip-device-ctrl > zcl ? Basic

--- a/src/controller/python/README.md
+++ b/src/controller/python/README.md
@@ -86,7 +86,7 @@ To build and run the Python CHIP controller:
 
 In this tutorial, the [Matter: Light Bulb](/examples/lighting-app) example with Bluetooth LE commissioning will be used, but similar steps can be executed with the rest of the examples. Check [Matter examples](/examples) for the list of available samples.
 
-Build and program the device with the Matter accessory firmware by following the example's documentation, for example [nRF Connect Lighting Example Application](/examples/lightigng-app/nrfconnect).
+Build and program the device with the Matter accessory firmware by following the example's documentation.
 
 ### 2. Enable Bluetooth LE advertising on Matter accessory device.
 
@@ -102,7 +102,7 @@ chip-device-ctrl > ble-scan
 
 ### 4. Connect to Matter accessory device over Bluetooth LE
 
-The controller uses a 12-bit value to discern between multiple commissionable device advertisements which is called **Discriminator**. The Matter accessory verifies the Controller by checking if the setup code is in his possession. You can find those values in the logging terminal of the device (e.g. UART), as listed below.
+The controller uses a 12-bit value called **discriminator** to discern between multiple commissionable device advertisements. Moreover, a 27-bit **PIN code** is used by the controller to authenticate in the device. You can find those values in the logging terminal of the device (e.g. UART), as listed below.
 
 ```
 I: 254 [DL]Device Configuration:
@@ -137,7 +137,7 @@ This means that the PASE (Password-Authenticated Session Establishment) session 
 
 ### 5. Commission Matter accessory to the underlying network
 
-One of the commissioning steps is Network Commissioning. The main goal of this step is to configure network interface, such as Thread or Wifi, and to provide network credentials.
+One of the commissioning steps is Network Commissioning. The main goal of this step is to configure a network interface, such as Thread or Wifi, on the device and to provide it with network credentials.
 
 #### Commissioning of Thread device
 
@@ -174,8 +174,6 @@ One of the commissioning steps is Network Commissioning. The main goal of this s
 
    > Each ZCL command has a following format:
       `zcl <Cluster> <Command> <Node Id> <Endpoint Id> <Group Id> [arguments]`
-   >
-   > Use the `zcl ? <Cluster>` command to list all available commands for given ZCL cluster.
 
    ```
    chip-device-ctrl > zcl NetworkCommissioning AddThreadNetwork 1234 0 0 operationalDataset=hex:0e080000000000010000000300001335060004001fffe002084fe76e9a8b5edaf50708fde46f999f0698e20510d47f5027a414ffeebaefa92285cc84fa030f4f70656e5468726561642d653439630102e49c0410b92f8c7fbb4f9f3e08492ee3915fbd2f0c0402a0fff8 breadcrumb=0 timeoutMs=3000
@@ -247,6 +245,8 @@ chip-device-ctrl > zclread Basic ProductName 1234 1 0
 chip-device-ctrl > zclread Basic SoftwareVersion 1234 1 0
 ```
 
+> Use the `zcl ? Basic` command to list all available commands for Basic Cluster.
+
 ## List of commands
 
 ### `ble-adapter-print`
@@ -268,7 +268,7 @@ chip-device-ctrl > ble-debug-log 1
 
 ### `ble-scan [-t <timeout>] [identifier]`
 
-Start a ble-scan action for searching valid CHIP devices over BLE [for at most
+Start a ble-scan action for searching valid CHIP devices over Bluetooth LE [for at most
 *timeout* seconds], stop when device matching the identifier or timeout.
 
 ```
@@ -302,7 +302,7 @@ If no nodeid given, a random node id will be used.
 ### `connect -ble <discriminator> <SetUpPinCode> [<nodeid>]`
 
 Do key exchange and establish a secure session between controller and device
-using BLE transport.
+using Bluetooth LE transport.
 
 The node id will be used by controller to distinguish multiple devices. This
 does not match the spec and will be removed later. The nodeid will not be
@@ -358,7 +358,7 @@ SetUpPINCode: 20202021
 
 ### `zcl <Cluster> <Command> <NodeId> <EndpointId> <GroupId> [arguments]`
 
-Send a ZCL command the device. For example:
+Send a ZCL command to the device. For example:
 
 ```
 chip-device-ctrl > zcl LevelControl MoveWithOnOff 12344321 1 0 moveMode=1 rate=2
@@ -381,7 +381,46 @@ List available clusters.
 
 ```
 chip-device-ctrl > zcl ?
-dict_keys(['BarrierControl', 'Basic', 'ColorControl', 'DoorLock', 'Groups', 'IasZone', 'Identify', 'LevelControl', 'NetworkProvisioning', 'OnOff', 'Scenes', 'TemperatureMeasurement'])
+AccountLogin
+ApplicationBasic
+ApplicationLauncher
+AudioOutput
+BarrierControl
+Basic
+Binding
+BridgedDeviceBasic
+ColorControl
+ContentLaunch
+Descriptor
+DoorLock
+EthernetNetworkDiagnostics
+FixedLabel
+GeneralCommissioning
+GeneralDiagnostics
+GroupKeyManagement
+Groups
+Identify
+KeypadInput
+LevelControl
+LowPower
+MediaInput
+MediaPlayback
+NetworkCommissioning
+OnOff
+OperationalCredentials
+PumpConfigurationAndControl
+RelativeHumidityMeasurement
+Scenes
+SoftwareDiagnostics
+Switch
+TvChannel
+TargetNavigator
+TemperatureMeasurement
+TestCluster
+Thermostat
+TrustedRootCertificates
+WakeOnLan
+WindowCovering
 ```
 
 ### `zcl ? <Cluster>`
@@ -389,23 +428,25 @@ dict_keys(['BarrierControl', 'Basic', 'ColorControl', 'DoorLock', 'Groups', 'Ias
 List available commands in cluster. For example, for *LevlControl* cluster:
 
 ```
-chip-device-ctrl > zcl ? LevelControl
-Move
-   moveMode: int, rate: int, optionMask: int, optionOverride: int
-MoveToLevel
-   level: int, transitionTime: int, optionMask: int, optionOverride: int
-MoveToLevelWithOnOff
-   level: int, transitionTime: int
-MoveWithOnOff
-   moveMode: int, rate: int
-Step
-   stepMode: int, stepSize: int, transitionTime: int, optionMask: int, optionOverride: int
-StepWithOnOff
-   stepMode: int, stepSize: int, transitionTime: int
-Stop
-   optionMask: int, optionOverride: int
-StopWithOnOff
-  <no arguments>
+chip-device-ctrl > zcl ? Basic
+InteractionModelVersion
+VendorName
+VendorID
+ProductName
+ProductID
+UserLabel
+Location
+HardwareVersion
+HardwareVersionString
+SoftwareVersion
+SoftwareVersionString
+ManufacturingDate
+PartNumber
+ProductURL
+ProductLabel
+SerialNumber
+LocalConfigDisabled
+ClusterRevision
 ```
 
 ### `zclread <Cluster> <Attribute> <NodeId> <EndpointId> <GroupId> [arguments]`
@@ -416,7 +457,7 @@ Read the value of ZCL attribute. For example:
 chip-device-ctrl > zclread Basic VendorName 1234 1 0
 ```
 
-#### `zclconfigure <Cluster> <Attribute> <Nodeid> <Endpoint> <MinInterval> <MaxInterval> <Change>`
+### `zclconfigure <Cluster> <Attribute> <Nodeid> <Endpoint> <MinInterval> <MaxInterval> <Change>`
 
 Configure ZCL attribute reporting settings. For example:
 


### PR DESCRIPTION
#### Problem
The Python CHIP controller documentation is not user-friendly.

#### Change overview
- Create a tutorial-like documentation
- Make commands list complete
- Move documentation about advanced features to the dedicated page. The content in `ADVANCED_USAGE.md` file, was just copied from the original version.

Some todos:
 - Unify the name of the tool
 - Should we mention nRF Connect at all?
 - Is it okay to use "platform" mDNS version by default?
 - Should we have a different step 2 (git clone) in case of sdk-connectedhomeip repo?

#### Testing
 - Building on Ubuntu/RaspberryPi
 - Testing on nRF Connect platform