### PR TITLE
[thread] delay scanning for Sleepy End Devices

### DIFF
--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.cpp
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.cpp
@@ -411,12 +411,14 @@ GenericThreadStackManagerImpl_OpenThread<ImplClass>::_StartThreadScan(NetworkCom
         mTemporaryRxOnWhenIdle = true;
         linkMode.mRxOnWhenIdle = true;
         otThreadSetLinkMode(mOTInst, linkMode);
+
+        // Delay Thread scanning to allow Child Update Request/Response transaction to finish.
+        DeviceLayer::SystemLayer().StartTimer(System::Clock::Milliseconds32(kThreadScanDelayMs), RequestThreadDiscovery, this);
+        ExitNow();
     }
 #endif
 
-    error = MapOpenThreadError(otThreadDiscover(mOTInst, 0,                       /* all channels */
-                                                OT_PANID_BROADCAST, false, false, /* disable PAN ID, EUI64 and Joiner filtering */
-                                                _OnNetworkScanFinished, this));
+    error = StartThreadDiscovery();
 
 exit:
     Impl()->UnlockThreadStack();
@@ -427,6 +429,38 @@ exit:
     }
 
     return error;
+}
+
+template <class ImplClass>
+void GenericThreadStackManagerImpl_OpenThread<ImplClass>::RequestThreadDiscovery(chip::System::Layer * apSystemLayer,
+                                                                                 void * apAppState)
+{
+    reinterpret_cast<GenericThreadStackManagerImpl_OpenThread *>(apAppState)->RequestThreadDiscovery();
+}
+
+template <class ImplClass>
+void GenericThreadStackManagerImpl_OpenThread<ImplClass>::RequestThreadDiscovery(void)
+{
+    Impl()->LockThreadStack();
+    CHIP_ERROR error = StartThreadDiscovery();
+    Impl()->UnlockThreadStack();
+
+    if (error != CHIP_NO_ERROR)
+    {
+        if (mpScanCallback != nullptr)
+        {
+            mpScanCallback->OnFinished(NetworkCommissioning::Status::kUnknownError, CharSpan(), nullptr);
+            mpScanCallback = nullptr;
+        }
+    }
+}
+
+template <class ImplClass>
+CHIP_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::StartThreadDiscovery(void)
+{
+    return MapOpenThreadError(otThreadDiscover(mOTInst, 0,                       /* all channels */
+                                               OT_PANID_BROADCAST, false, false, /* disable PAN ID, EUI64 and Joiner filtering */
+                                               _OnNetworkScanFinished, this));
 }
 
 template <class ImplClass>
@@ -1918,7 +1952,7 @@ CHIP_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::_RequestSEDActiv
 }
 
 template <class ImplClass>
-CHIP_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::SEDUpdateMode()
+CHIP_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::SEDUpdateMode(void)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     ConnectivityManager::SEDIntervalMode mode;
@@ -2032,7 +2066,7 @@ exit:
 }
 
 template <class ImplClass>
-void GenericThreadStackManagerImpl_OpenThread<ImplClass>::_UpdateNetworkStatus()
+void GenericThreadStackManagerImpl_OpenThread<ImplClass>::_UpdateNetworkStatus(void)
 {
     // Thread is not enabled, then we are not trying to connect to the network.
     VerifyOrReturn(ThreadStackMgrImpl().IsThreadEnabled() && mpStatusChangeCallback != nullptr);

--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.h
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.h
@@ -98,13 +98,16 @@ protected:
     CHIP_ERROR _StartThreadScan(NetworkCommissioning::ThreadDriver::ScanCallback * callback);
     static void _OnNetworkScanFinished(otActiveScanResult * aResult, void * aContext);
     void _OnNetworkScanFinished(otActiveScanResult * aResult);
-    void _UpdateNetworkStatus();
+    CHIP_ERROR StartThreadDiscovery(void);
+    static void RequestThreadDiscovery(chip::System::Layer * apSystemLayer, void * apAppState);
+    void RequestThreadDiscovery(void);
+    void _UpdateNetworkStatus(void);
 
 #if CHIP_DEVICE_CONFIG_ENABLE_SED
     CHIP_ERROR _GetSEDIntervalsConfig(ConnectivityManager::SEDIntervalsConfig & intervalsConfig);
     CHIP_ERROR _SetSEDIntervalsConfig(const ConnectivityManager::SEDIntervalsConfig & intervalsConfig);
     CHIP_ERROR _RequestSEDActiveMode(bool onOff, bool delayIdle);
-    CHIP_ERROR SEDUpdateMode();
+    CHIP_ERROR SEDUpdateMode(void);
     static void RequestSEDModeUpdate(chip::System::Layer * apSystemLayer, void * apAppState);
 #endif
 
@@ -165,6 +168,7 @@ private:
     ConnectivityManager::SEDIntervalMode mIntervalsMode = ConnectivityManager::SEDIntervalMode::Idle;
     uint32_t mActiveModeConsumers                       = 0;
     bool mDelayIdleTimerRunning                         = false;
+    static constexpr uint32_t kThreadScanDelayMs        = 300;
 #endif
 
 #if CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT


### PR DESCRIPTION
When SED changes its mode from RxOffWhenIdle to RxOnWhenIdle (by sending Child Update Request) and immediately starts the Thread Discovery procedure (on all channels) it is not able to receive the Child Update Response from its parent. This causes a lot of retransmissions from the parent side and even sporadic re-attachments.

This PR adds a small 300-ms delay to allow the child to receive the Child Update Response.
